### PR TITLE
Enable use of polynomial density, calculating average density per costheta trajectory

### DIFF
--- a/cpupropagator.hpp
+++ b/cpupropagator.hpp
@@ -81,6 +81,7 @@ namespace cudaprob3{
     public:
 
         void calculateProbabilities(NeutrinoType type) override{
+
             if(!this->isInit)
                 throw std::runtime_error("CpuPropagator::calculateProbabilities. Object has been moved from.");
             if(!this->isSetProductionHeight)
@@ -92,9 +93,34 @@ namespace cudaprob3{
             physics::setMixMatrix_host(this->Mix_U.data());
             physics::setMassDifferences_host(this->dm.data());
 
-            physics::calculate(type, this->cosineList.data(), this->cosineList.size(),
-			       this->energyList.data(), this->energyList.size(), this->radii.data(), this->rhos.data(), this->yps.data(), this->maxlayers.data(), this->ProductionHeightinCentimeter, this->useProductionHeightAveraging, this->nProductionHeightBins,
-			       this->productionHeightList_prob.data(), this->productionHeightList_bins.data(), resultList.data());
+            /*
+            // Set the physicals
+            physics::calculate(type, 
+                this->cosineList.data(), this->cosineList.size(),
+                this->energyList.data(), this->energyList.size(), 
+                this->radii.data(), this->rhos.data(), this->yps.data(), 
+                this->maxlayers.data(), 
+                this->ProductionHeightinCentimeter, this->useProductionHeightAveraging, this->nProductionHeightBins,
+                this->productionHeightList_prob.data(), this->productionHeightList_bins.data(), resultList.data());
+            */
+            physics::calculate(type, 
+                this->cosineList.data(), 
+                this->cosineList.size(),
+                this->energyList.data(), 
+                this->energyList.size(), 
+                this->radii.data(), 
+                this->as.data(), 
+                this->bs.data(), 
+                this->cs.data(), 
+                this->rhos.data(), 
+                this->yps.data(), 
+                this->maxlayers.data(), 
+                this->ProductionHeightinCentimeter,
+                this->useProductionHeightAveraging,
+                this->nProductionHeightBins,
+                this->productionHeightList_prob.data(), 
+                this->productionHeightList_bins.data(), 
+                resultList.data());
         }
 
       void setChemicalComposition(const std::vector<FLOAT_T>& list) override{

--- a/cpupropagator.hpp
+++ b/cpupropagator.hpp
@@ -93,16 +93,6 @@ namespace cudaprob3{
             physics::setMixMatrix_host(this->Mix_U.data());
             physics::setMassDifferences_host(this->dm.data());
 
-            /*
-            // Set the physicals
-            physics::calculate(type, 
-                this->cosineList.data(), this->cosineList.size(),
-                this->energyList.data(), this->energyList.size(), 
-                this->radii.data(), this->rhos.data(), this->yps.data(), 
-                this->maxlayers.data(), 
-                this->ProductionHeightinCentimeter, this->useProductionHeightAveraging, this->nProductionHeightBins,
-                this->productionHeightList_prob.data(), this->productionHeightList_bins.data(), resultList.data());
-            */
             physics::calculate(type, 
                 this->cosineList.data(), 
                 this->cosineList.size(),
@@ -120,42 +110,43 @@ namespace cudaprob3{
                 this->nProductionHeightBins,
                 this->productionHeightList_prob.data(), 
                 this->productionHeightList_bins.data(), 
+                this->UsePolyDensity, // Are we using constant density or polynomial?
                 resultList.data());
         }
 
-      void setChemicalComposition(const std::vector<FLOAT_T>& list) override{
-        if (list.size() != this->yps.size()) {
-          throw std::runtime_error("CpuPropagator::setChemicalComposition. Size of input list not equal to expectation.");
+        void setChemicalComposition(const std::vector<FLOAT_T>& list) override{
+          if (list.size() != this->yps.size()) {
+            throw std::runtime_error("CpuPropagator::setChemicalComposition. Size of input list not equal to expectation.");
+          }
+
+          for (int iyp=0;iyp<list.size();iyp++) {
+            this->yps[iyp] = list[iyp];
+          }
+
         }
-	
-        for (int iyp=0;iyp<list.size();iyp++) {
-          this->yps[iyp] = list[iyp];
-        }
-	
-      }
 
         FLOAT_T getProbability(int index_cosine, int index_energy, ProbType t) override{
-	  if(index_cosine >= this->n_cosines || index_energy >= this->n_energies) {
-	    throw std::runtime_error("CpuPropagator::getProbability. Invalid indices");
-	  }
+          if(index_cosine >= this->n_cosines || index_energy >= this->n_energies) {
+            throw std::runtime_error("CpuPropagator::getProbability. Invalid indices");
+          }
 
-            std::uint64_t index = std::uint64_t(index_cosine) * std::uint64_t(this->n_energies) * std::uint64_t(9)
-                    + std::uint64_t(index_energy) * std::uint64_t(9);
-            return resultList[index + int(t)];
+          std::uint64_t index = std::uint64_t(index_cosine) * std::uint64_t(this->n_energies) * std::uint64_t(9)
+            + std::uint64_t(index_energy) * std::uint64_t(9);
+          return resultList[index + int(t)];
         }
 
-      void getProbabilityArr(FLOAT_T* probArr, ProbType t) override{
+        void getProbabilityArr(FLOAT_T* probArr, ProbType t) override{
 
-	std::uint64_t iter = 0;
-	for (std::uint64_t index_energy=0;index_energy<this->n_energies;index_energy++) {
-	  for (std::uint64_t index_cosine=0;index_cosine<this->n_cosines;index_cosine++) {
-	    std::uint64_t index = std::uint64_t(index_cosine) * std::uint64_t(this->n_energies) * std::uint64_t(9) + std::uint64_t(index_energy) * std::uint64_t(9);
-	    probArr[iter] = resultList[index + int(t)];
-	    iter += 1;
-	  }
-	}
+          std::uint64_t iter = 0;
+          for (std::uint64_t index_energy=0;index_energy<this->n_energies;index_energy++) {
+            for (std::uint64_t index_cosine=0;index_cosine<this->n_cosines;index_cosine++) {
+              std::uint64_t index = std::uint64_t(index_cosine) * std::uint64_t(this->n_energies) * std::uint64_t(9) + std::uint64_t(index_energy) * std::uint64_t(9);
+              probArr[iter] = resultList[index + int(t)];
+              iter += 1;
+            }
+          }
 
-      }
+        }
 
     private:
         std::vector<FLOAT_T> resultList;

--- a/cudapropagator.cuh
+++ b/cudapropagator.cuh
@@ -294,24 +294,6 @@ namespace cudaprob3{
 
           dim3 grid(blocks, 1, 1);
 
-/*
-          physics::callCalculateKernelAsync(grid, block, stream,
-              type,
-              d_cosine_list.get(), 
-              this->n_cosines,
-              d_energy_list.get(), 
-              this->n_energies,
-              d_radii.get(), 
-              d_rhos.get(), 
-              d_yps.get(),
-              d_maxlayers.get(),
-              this->ProductionHeightinCentimeter,
-              this->useProductionHeightAveraging,
-              this->nProductionHeightBins,
-              d_productionHeight_prob_list.get(),
-              d_productionHeight_bins_list.get(),
-              d_result_list.get());
-              */
           physics::callCalculateKernelAsync(grid, block, stream,
               type,
               d_cosine_list.get(), 
@@ -330,6 +312,7 @@ namespace cudaprob3{
               this->nProductionHeightBins,
               d_productionHeight_prob_list.get(),
               d_productionHeight_bins_list.get(),
+              this->UsePolyDensity,
               d_result_list.get());
 
           CUERR;
@@ -353,7 +336,9 @@ namespace cudaprob3{
     private:
         unique_pinned_ptr<FLOAT_T> resultList;
 
+        // density
         unique_dev_ptr<FLOAT_T> d_rhos;
+
         // Polynomial coefficients
         unique_dev_ptr<FLOAT_T> d_as;
         unique_dev_ptr<FLOAT_T> d_bs;

--- a/cudapropagator.cuh
+++ b/cudapropagator.cuh
@@ -37,7 +37,7 @@ namespace cudaprob3{
     /// \brief Single-GPU neutrino propagation. Derived from Propagator
     /// @param FLOAT_T The floating point type to use for calculations, i.e float, double
     template<class FLOAT_T>
-    class CudaPropagatorSingle : public Propagator<FLOAT_T>{
+    class CudaPropagatorSingle : public Propagator<FLOAT_T> {
         template<typename>
         friend class CudaPropagator;
     public:
@@ -134,48 +134,51 @@ namespace cudaprob3{
 
     public:
 
-        void setDensity(const std::vector<FLOAT_T>& radii_, const std::vector<FLOAT_T>& rhos_, const std::vector<FLOAT_T>& yps_) override{
-            // call parent function to set up host density data
-            Propagator<FLOAT_T>::setDensity(radii_, rhos_, yps_);
+        void setDensity(
+          const std::vector<FLOAT_T>& radii_, 
+          const std::vector<FLOAT_T>& rhos_, 
+          const std::vector<FLOAT_T>& yps_) override{
+          // call parent function to set up host density data
+          Propagator<FLOAT_T>::setDensity(radii_, rhos_, yps_);
 
-            // allocate GPU arrays for density information and copy host density data to device density data
-            cudaSetDevice(deviceId); CUERR;
+          // allocate GPU arrays for density information and copy host density data to device density data
+          cudaSetDevice(deviceId); CUERR;
 
-            int nDensityLayers = this->radii.size();
-	    
-            d_rhos = make_unique_dev<FLOAT_T>(deviceId, 2 * nDensityLayers + 1);
-	    d_yps = make_unique_dev<FLOAT_T>(deviceId, 2 * nDensityLayers + 1);
-            d_radii = make_unique_dev<FLOAT_T>(deviceId, 2 * nDensityLayers + 1);
+          int nDensityLayers = this->radii.size();
 
-            cudaMemcpy(d_rhos.get(), this->rhos.data(), sizeof(FLOAT_T) * nDensityLayers, H2D); CUERR;
-	    cudaMemcpy(d_yps.get(), this->yps.data(), sizeof(FLOAT_T) * nDensityLayers, H2D); CUERR;
-            cudaMemcpy(d_radii.get(), this->radii.data(), sizeof(FLOAT_T) * nDensityLayers, H2D); CUERR;
+          d_rhos = make_unique_dev<FLOAT_T>(deviceId, 2 * nDensityLayers + 1);
+          d_yps = make_unique_dev<FLOAT_T>(deviceId, 2 * nDensityLayers + 1);
+          d_radii = make_unique_dev<FLOAT_T>(deviceId, 2 * nDensityLayers + 1);
+
+          cudaMemcpy(d_rhos.get(), this->rhos.data(), sizeof(FLOAT_T) * nDensityLayers, H2D); CUERR;
+          cudaMemcpy(d_yps.get(), this->yps.data(), sizeof(FLOAT_T) * nDensityLayers, H2D); CUERR;
+          cudaMemcpy(d_radii.get(), this->radii.data(), sizeof(FLOAT_T) * nDensityLayers, H2D); CUERR;
         }
 
         void setEnergyList(const std::vector<FLOAT_T>& list) override{
-            Propagator<FLOAT_T>::setEnergyList(list); // set host energy list
+          Propagator<FLOAT_T>::setEnergyList(list); // set host energy list
 
-            //copy host energy list to gpu memory
-            cudaMemcpy(d_energy_list.get(), this->energyList.data(), sizeof(FLOAT_T) * this->n_energies, H2D); CUERR;
+          //copy host energy list to gpu memory
+          cudaMemcpy(d_energy_list.get(), this->energyList.data(), sizeof(FLOAT_T) * this->n_energies, H2D); CUERR;
         }
 
         void setCosineList(const std::vector<FLOAT_T>& list) override{
-            Propagator<FLOAT_T>::setCosineList(list); // set host cosine list
-            //copy host cosine list to gpu memory
-            cudaMemcpy(d_cosine_list.get(), this->cosineList.data(), sizeof(FLOAT_T) * this->n_cosines, H2D); CUERR;
+          Propagator<FLOAT_T>::setCosineList(list); // set host cosine list
+          //copy host cosine list to gpu memory
+          cudaMemcpy(d_cosine_list.get(), this->cosineList.data(), sizeof(FLOAT_T) * this->n_cosines, H2D); CUERR;
         }
 
-	void setProductionHeightList(const std::vector<FLOAT_T>& list_prob, const std::vector<FLOAT_T>& list_bins) override{
-	    Propagator<FLOAT_T>::setProductionHeightList(list_prob, list_bins); //set host production height list
+        void setProductionHeightList(const std::vector<FLOAT_T>& list_prob, const std::vector<FLOAT_T>& list_bins) override{
+          Propagator<FLOAT_T>::setProductionHeightList(list_prob, list_bins); //set host production height list
 
-	    cudaMemcpy(d_productionHeight_prob_list.get(), this->productionHeightList_prob.data(), sizeof(FLOAT_T)*Constants<FLOAT_T>::MaxProdHeightBins()*2*3*this->n_energies*this->n_cosines, H2D); CUERR;
-	    cudaMemcpy(d_productionHeight_bins_list.get(), this->productionHeightList_bins.data(), sizeof(FLOAT_T)*(Constants<FLOAT_T>::MaxProdHeightBins()+1), H2D); CUERR;
-	}
+          cudaMemcpy(d_productionHeight_prob_list.get(), this->productionHeightList_prob.data(), sizeof(FLOAT_T)*Constants<FLOAT_T>::MaxProdHeightBins()*2*3*this->n_energies*this->n_cosines, H2D); CUERR;
+          cudaMemcpy(d_productionHeight_bins_list.get(), this->productionHeightList_bins.data(), sizeof(FLOAT_T)*(Constants<FLOAT_T>::MaxProdHeightBins()+1), H2D); CUERR;
+        }
 
         // calculate the probability of each cell
         void calculateProbabilities(NeutrinoType type) override{
-            calculateProbabilitiesAsync(type);
-            waitForCompletion();
+          calculateProbabilitiesAsync(type);
+          waitForCompletion();
         }
 
         void setChemicalComposition(const std::vector<FLOAT_T>& list) override{
@@ -194,108 +197,108 @@ namespace cudaprob3{
 
         // get oscillation weight for specific cosine and energy
         FLOAT_T getProbability(int index_cosine, int index_energy, ProbType t) override{
-            if(index_cosine >= this->n_cosines || index_energy >= this->n_energies)
-                throw std::runtime_error("CudaPropagatorSingle::getProbability. Invalid indices");
+          if(index_cosine >= this->n_cosines || index_energy >= this->n_energies)
+            throw std::runtime_error("CudaPropagatorSingle::getProbability. Invalid indices");
 
-            if(!resultsResideOnHost){
-                getResultFromDevice();
-                resultsResideOnHost = true;
-            }
+          if(!resultsResideOnHost){
+            getResultFromDevice();
+            resultsResideOnHost = true;
+          }
 
-            const std::uint64_t index = std::uint64_t(index_cosine) * std::uint64_t(this->n_energies) + std::uint64_t(index_energy);
-            const std::uint64_t offset = std::uint64_t(t) * std::uint64_t(this->n_energies) * std::uint64_t(this->n_cosines);
+          const std::uint64_t index = std::uint64_t(index_cosine) * std::uint64_t(this->n_energies) + std::uint64_t(index_energy);
+          const std::uint64_t offset = std::uint64_t(t) * std::uint64_t(this->n_energies) * std::uint64_t(this->n_cosines);
 
-            return resultList.get()[index + offset];
+          return resultList.get()[index + offset];
         }
 
         // get oscillation weight for specific cosine and energy
         void getProbabilityArr(FLOAT_T* probArr, ProbType t) {
 
-            if(!resultsResideOnHost){
-		getResultFromDevice();
-                resultsResideOnHost = true;
+          if(!resultsResideOnHost){
+            getResultFromDevice();
+            resultsResideOnHost = true;
+          }
+
+          FLOAT_T* resultList_Arr = resultList.get();
+          const std::uint64_t offset = std::uint64_t(t) * std::uint64_t(this->n_energies) * std::uint64_t(this->n_cosines);
+
+          std::uint64_t iter = 0;
+          for (std::uint64_t index_energy=0;index_energy<this->n_energies;index_energy++) {
+            for (std::uint64_t index_cosine=0;index_cosine<this->n_cosines;index_cosine++) {
+              std::uint64_t index = std::uint64_t(index_cosine) * std::uint64_t(this->n_energies) + std::uint64_t(index_energy);
+              probArr[iter] = resultList_Arr[index + offset];
+              iter += 1;
             }
-
-	    FLOAT_T* resultList_Arr = resultList.get();
-            const std::uint64_t offset = std::uint64_t(t) * std::uint64_t(this->n_energies) * std::uint64_t(this->n_cosines);
-
-	    std::uint64_t iter = 0;
-	    for (std::uint64_t index_energy=0;index_energy<this->n_energies;index_energy++) {
-	    	for (std::uint64_t index_cosine=0;index_cosine<this->n_cosines;index_cosine++) {
-            	    std::uint64_t index = std::uint64_t(index_cosine) * std::uint64_t(this->n_energies) + std::uint64_t(index_energy);
-		    probArr[iter] = resultList_Arr[index + offset];
-		    iter += 1;
-		}
-	     }
+          }
 
         }
 
     protected:
         void setMaxlayers() override{
-            Propagator<FLOAT_T>::setMaxlayers();
+          Propagator<FLOAT_T>::setMaxlayers();
 
-            cudaMemcpy(d_maxlayers.get(), this->maxlayers.data(), sizeof(int) * this->n_cosines, H2D); CUERR;
+          cudaMemcpy(d_maxlayers.get(), this->maxlayers.data(), sizeof(int) * this->n_cosines, H2D); CUERR;
         }
 
         // launch the calculation kernel without waiting for its completion
         void calculateProbabilitiesAsync(NeutrinoType type){
-            if(!this->isInit)
-                throw std::runtime_error("CudaPropagatorSingle::calculateProbabilities. Object has been moved from.");
-            if(!this->isSetProductionHeight)
-                throw std::runtime_error("CudaPropagatorSingle::calculateProbabilities. production height was not set");
-            if(this->useProductionHeightAveraging && !this->isSetProductionHeightArray)
-                throw std::runtime_error("CudaPropagatorSingle::calculateProbabilities. production height array was not set");
+          if(!this->isInit)
+            throw std::runtime_error("CudaPropagatorSingle::calculateProbabilities. Object has been moved from.");
+          if(!this->isSetProductionHeight)
+            throw std::runtime_error("CudaPropagatorSingle::calculateProbabilities. production height was not set");
+          if(this->useProductionHeightAveraging && !this->isSetProductionHeightArray)
+            throw std::runtime_error("CudaPropagatorSingle::calculateProbabilities. production height array was not set");
 
-            resultsResideOnHost = false;
-            cudaSetDevice(deviceId); CUERR;
+          resultsResideOnHost = false;
+          cudaSetDevice(deviceId); CUERR;
 
-            // set neutrino parameters for core physics functions for both host and device
-            physics::setMixMatrix(this->Mix_U.data());
-            physics::setMassDifferences(this->dm.data());
+          // set neutrino parameters for core physics functions for both host and device
+          physics::setMixMatrix(this->Mix_U.data());
+          physics::setMassDifferences(this->dm.data());
 
-            dim3 block(64, 1, 1);
+          dim3 block(64, 1, 1);
 
-            //const unsigned blocks = SDIV(this->energyList.size() * this->cosineList.size(), block.x);
-            const unsigned blocks = SDIV(this->energyList.size(), block.x) * this->cosineList.size();
+          //const unsigned blocks = SDIV(this->energyList.size() * this->cosineList.size(), block.x);
+          const unsigned blocks = SDIV(this->energyList.size(), block.x) * this->cosineList.size();
 
-            dim3 grid(blocks, 1, 1);
+          dim3 grid(blocks, 1, 1);
 
-            physics::callCalculateKernelAsync(grid, block, stream,
-                            type,
-                            d_cosine_list.get(), this->n_cosines,
-                            d_energy_list.get(), this->n_energies,
-                            d_radii.get(), d_rhos.get(), d_yps.get(),
-                            d_maxlayers.get(),
-			    this->ProductionHeightinCentimeter,
-			    this->useProductionHeightAveraging,
-			    this->nProductionHeightBins,
-			    d_productionHeight_prob_list.get(),
-			    d_productionHeight_bins_list.get(),
-                            d_result_list.get());
+          physics::callCalculateKernelAsync(grid, block, stream,
+              type,
+              d_cosine_list.get(), this->n_cosines,
+              d_energy_list.get(), this->n_energies,
+              d_radii.get(), d_rhos.get(), d_yps.get(),
+              d_maxlayers.get(),
+              this->ProductionHeightinCentimeter,
+              this->useProductionHeightAveraging,
+              this->nProductionHeightBins,
+              d_productionHeight_prob_list.get(),
+              d_productionHeight_bins_list.get(),
+              d_result_list.get());
 
-            CUERR;
+          CUERR;
         }
 
         // wait for calculateProbabilitiesAsync to finish
         void waitForCompletion(){
-            cudaSetDevice(deviceId); CUERR;
-            cudaStreamSynchronize(stream); CUERR;
+          cudaSetDevice(deviceId); CUERR;
+          cudaStreamSynchronize(stream); CUERR;
         }
 
         // copy results from device to host
         void getResultFromDevice(){
-            cudaSetDevice(deviceId); CUERR;
-            cudaMemcpyAsync(resultList.get(), d_result_list.get(),
-                            sizeof(FLOAT_T) * std::uint64_t(9) * std::uint64_t(this->n_energies) * std::uint64_t(this->n_cosines),
-                            D2H, stream);  CUERR;
-            cudaStreamSynchronize(stream);
+          cudaSetDevice(deviceId); CUERR;
+          cudaMemcpyAsync(resultList.get(), d_result_list.get(),
+              sizeof(FLOAT_T) * std::uint64_t(9) * std::uint64_t(this->n_energies) * std::uint64_t(this->n_cosines),
+              D2H, stream);  CUERR;
+          cudaStreamSynchronize(stream);
         }
 
     private:
         unique_pinned_ptr<FLOAT_T> resultList;
 
         unique_dev_ptr<FLOAT_T> d_rhos;
-	unique_dev_ptr<FLOAT_T> d_yps;
+        unique_dev_ptr<FLOAT_T> d_yps;
         unique_dev_ptr<FLOAT_T> d_radii;
         unique_dev_ptr<int> d_maxlayers;
         unique_dev_ptr<FLOAT_T> d_energy_list;
@@ -316,21 +319,21 @@ namespace cudaprob3{
     /// Most of the setters and calculation functions simply call the appropriate function for each GPU
     /// @param FLOAT_T The floating point type to use for calculations, i.e float, double
     template<class FLOAT_T>
-    class CudaPropagator : public Propagator<FLOAT_T>{
-    public:
-        /// \brief Single GPU constructor for device id 0
-        ///
-        /// @param nc Number cosine bins
-        /// @param ne Number of energy bins
-        CudaPropagator(int nc, int ne) : CudaPropagator(std::vector<int>{0}, nc, ne, true){}
+      class CudaPropagator : public Propagator<FLOAT_T>{
+        public:
+          /// \brief Single GPU constructor for device id 0
+          ///
+          /// @param nc Number cosine bins
+          /// @param ne Number of energy bins
+          CudaPropagator(int nc, int ne) : CudaPropagator(std::vector<int>{0}, nc, ne, true){}
 
-        /// \brief Constructor
-        ///
-        /// @param ids List of device ids of the GPUs to use
-        /// @param nc Number cosine bins
-        /// @param ne Number of energy bins
-        /// @param failOnInvalidId If true, throw exception if ids contains an invalid device id
-        CudaPropagator(const std::vector<int>& ids, int nc, int ne, bool failOnInvalidId = true) : Propagator<FLOAT_T>(nc, ne) {
+          /// \brief Constructor
+          ///
+          /// @param ids List of device ids of the GPUs to use
+          /// @param nc Number cosine bins
+          /// @param ne Number of energy bins
+          /// @param failOnInvalidId If true, throw exception if ids contains an invalid device id
+          CudaPropagator(const std::vector<int>& ids, int nc, int ne, bool failOnInvalidId = true) : Propagator<FLOAT_T>(nc, ne) {
 
             int nDevices;
             cudaGetDeviceCount(&nDevices);
@@ -338,61 +341,61 @@ namespace cudaprob3{
             if(nDevices == 0) throw std::runtime_error("No GPU found");
 
             for(const auto& id: ids){
-                if(id >= nDevices){
-                    if(failOnInvalidId){
-                        std::cout << "Available GPUs:" << std::endl;
-                        for(int j = 0; j < nDevices; j++){
-                            cudaDeviceProp prop;
-                            cudaGetDeviceProperties(&prop, j);
-                            std::cout << "Id " << j << " : " << prop.name << std::endl;
-                        }
-                        throw std::runtime_error("The requested GPU Id " + std::to_string(id) + " is not available.");
-                    }else{
-                        std::cout << "invalid device id found : " << id << std::endl;
-                    }
+              if(id >= nDevices){
+                if(failOnInvalidId){
+                  std::cout << "Available GPUs:" << std::endl;
+                  for(int j = 0; j < nDevices; j++){
+                    cudaDeviceProp prop;
+                    cudaGetDeviceProperties(&prop, j);
+                    std::cout << "Id " << j << " : " << prop.name << std::endl;
+                  }
+                  throw std::runtime_error("The requested GPU Id " + std::to_string(id) + " is not available.");
                 }else{
-                    deviceIds.push_back(id);
+                  std::cout << "invalid device id found : " << id << std::endl;
                 }
+              }else{
+                deviceIds.push_back(id);
+              }
             }
 
             if(deviceIds.size() == 0){
-                throw std::runtime_error("No valid device id found.");
+              throw std::runtime_error("No valid device id found.");
             }
             cosineIndices.resize(deviceIds.size());
             localCosineIndices.resize(this->n_cosines);
 
             for(int icos = 0; icos < this->n_cosines; icos++){
 
-                int deviceIndex = getCosineDeviceIndex(icos);
+              int deviceIndex = getCosineDeviceIndex(icos);
 
-                cosineIndices[deviceIndex].push_back(icos);
-                // the icos-th path is processed by GPU deviceIndex.
-                // In the subproblem processed by GPU deviceIndex, the icos-th path is the localCosineIndices[icos]-th path
-                localCosineIndices[icos] = cosineIndices[deviceIndex].size() - 1;
+              cosineIndices[deviceIndex].push_back(icos);
+              // the icos-th path is processed by GPU deviceIndex.
+              // In the subproblem processed by GPU deviceIndex, the icos-th path is the localCosineIndices[icos]-th path
+              localCosineIndices[icos] = cosineIndices[deviceIndex].size() - 1;
             }
 
             for(size_t i = 0; i < deviceIds.size() && i < size_t(this->n_cosines); i++){
-                propagatorVector.push_back(
-                    std::unique_ptr<CudaPropagatorSingle<FLOAT_T>>(
-                        new CudaPropagatorSingle<FLOAT_T>(deviceIds[i], cosineIndices[i].size(), this->n_energies)
+              propagatorVector.push_back(
+                  std::unique_ptr<CudaPropagatorSingle<FLOAT_T>>(
+                    new CudaPropagatorSingle<FLOAT_T>(deviceIds[i], cosineIndices[i].size(), this->n_energies)
                     )
-                );
+                  );
             }
-        }
+          }
 
-        CudaPropagator(const CudaPropagator& other) = delete;
+          CudaPropagator(const CudaPropagator& other) = delete;
 
-        /// \brief Move constructor
-        /// @param other
-        CudaPropagator(CudaPropagator&& other) : Propagator<FLOAT_T>(other){
+          /// \brief Move constructor
+          /// @param other
+          CudaPropagator(CudaPropagator&& other) : Propagator<FLOAT_T>(other){
             *this = std::move(other);
-        }
+          }
 
-        CudaPropagator& operator=(const CudaPropagator& other) = delete;
+          CudaPropagator& operator=(const CudaPropagator& other) = delete;
 
-        /// \brief Move assignment operator
-        /// @param other
-        CudaPropagator& operator=(CudaPropagator&& other){
+          /// \brief Move assignment operator
+          /// @param other
+          CudaPropagator& operator=(CudaPropagator&& other){
             Propagator<FLOAT_T>::operator=(std::move(other));
 
             deviceIds = std::move(other.deviceIds);
@@ -402,124 +405,139 @@ namespace cudaprob3{
             propagatorVector = std::move(other.propagatorVector);
 
             return *this;
-        }
+          }
 
-    public:
+        public:
 
-        void setDensityFromFile(const std::string& filename) override{
+          void setDensityFromFile(const std::string& filename) override{
             Propagator<FLOAT_T>::setDensityFromFile(filename);
 
             for(auto& propagator : propagatorVector)
-                propagator->setDensityFromFile(filename);
-        }
+              propagator->setDensityFromFile(filename);
+          }
 
-        void setDensity(const std::vector<FLOAT_T>& radii, const std::vector<FLOAT_T>& rhos, const std::vector<FLOAT_T>& yps) override{
+          void setDensity(
+              const std::vector<FLOAT_T>& radii, 
+              const std::vector<FLOAT_T>& rhos, 
+              const std::vector<FLOAT_T>& yps) override{
             Propagator<FLOAT_T>::setDensity(radii, rhos, yps);
 
             for(auto& propagator : propagatorVector)
-                propagator->setDensity(radii, rhos, yps);
-        }
+              propagator->setDensity(radii, rhos, yps);
+          }
 
-        void setNeutrinoMasses(FLOAT_T dm12sq, FLOAT_T dm23sq) override{
+          void setDensity(
+              const std::vector<FLOAT_T>& radii, 
+              const std::vector<FLOAT_T>& a, 
+              const std::vector<FLOAT_T>& b, 
+              const std::vector<FLOAT_T>& c, 
+              const std::vector<FLOAT_T>& yps) override{
+            Propagator<FLOAT_T>::setDensity(radii, a, b, c, yps);
+
+            for(auto& propagator : propagatorVector)
+              propagator->setDensity(radii, a, b, c, yps);
+          }
+
+          void setNeutrinoMasses(FLOAT_T dm12sq, FLOAT_T dm23sq) override{
             Propagator<FLOAT_T>::setNeutrinoMasses(dm12sq, dm23sq);
 
             for(auto& propagator : propagatorVector)
-                propagator->setNeutrinoMasses(dm12sq, dm23sq);
-        }
+              propagator->setNeutrinoMasses(dm12sq, dm23sq);
+          }
 
-        void setMNSMatrix(FLOAT_T theta12, FLOAT_T theta13, FLOAT_T theta23, FLOAT_T dCP) override{
+          void setMNSMatrix(FLOAT_T theta12, FLOAT_T theta13, FLOAT_T theta23, FLOAT_T dCP) override{
             Propagator<FLOAT_T>::setMNSMatrix(theta12, theta13, theta23, dCP);
 
             for(auto& propagator : propagatorVector)
-                propagator->setMNSMatrix(theta12, theta13, theta23, dCP);
-        }
+              propagator->setMNSMatrix(theta12, theta13, theta23, dCP);
+          }
 
-        void setEnergyList(const std::vector<FLOAT_T>& list) override{
+          void setEnergyList(const std::vector<FLOAT_T>& list) override{
             Propagator<FLOAT_T>::setEnergyList(list);
 
             for(auto& propagator : propagatorVector)
-                propagator->setEnergyList(list);
-        }
+              propagator->setEnergyList(list);
+          }
 
-        void setCosineList(const std::vector<FLOAT_T>& list) override{
+          void setCosineList(const std::vector<FLOAT_T>& list) override{
             Propagator<FLOAT_T>::setCosineList(list);
 
             for(size_t i = 0; i < propagatorVector.size(); i++){
-                // make list of cosines for GPU i and pass it to propagator i
-                std::vector<FLOAT_T> myCos(cosineIndices[i].size());
-                std::transform(cosineIndices[i].begin(),
-                                cosineIndices[i].end(),
-                                myCos.begin(),
-                                [&](int icos){ return this->cosineList[icos]; }
-                );
-                propagatorVector[i]->setCosineList(myCos);
+              // make list of cosines for GPU i and pass it to propagator i
+              std::vector<FLOAT_T> myCos(cosineIndices[i].size());
+              std::transform(cosineIndices[i].begin(),
+                  cosineIndices[i].end(),
+                  myCos.begin(),
+                  [&](int icos){ return this->cosineList[icos]; }
+                  );
+              propagatorVector[i]->setCosineList(myCos);
             }
-        }
+          }
 
-        void setProductionHeight(FLOAT_T heightKM) override{
+          void setProductionHeight(FLOAT_T heightKM) override{
             Propagator<FLOAT_T>::setProductionHeight(heightKM);
 
             for(auto& propagator : propagatorVector)
-                propagator->setProductionHeight(heightKM);
-        }
+              propagator->setProductionHeight(heightKM);
+          }
 
-    public:
-        void calculateProbabilities(NeutrinoType type) override{
-
-            for(auto& propagator : propagatorVector)
-                    propagator->calculateProbabilitiesAsync(type);
+        public:
+          void calculateProbabilities(NeutrinoType type) override{
 
             for(auto& propagator : propagatorVector)
-                    propagator->waitForCompletion();
-        }
+              propagator->calculateProbabilitiesAsync(type);
 
-        FLOAT_T getProbability(int index_cosine, int index_energy, ProbType t) override{
-                const int deviceIndex = getCosineDeviceIndex(index_cosine);
-                const int localCosineIndex = localCosineIndices[index_cosine];
+            for(auto& propagator : propagatorVector)
+              propagator->waitForCompletion();
+          }
 
-                return propagatorVector[deviceIndex]->getProbability(localCosineIndex, index_energy, t);
-        }
+          FLOAT_T getProbability(int index_cosine, int index_energy, ProbType t) override{
+            const int deviceIndex = getCosineDeviceIndex(index_cosine);
+            const int localCosineIndex = localCosineIndices[index_cosine];
 
-        void getProbabilityArr(FLOAT_T* probArr, ProbType t) {
-	     	throw std::runtime_error("CudaPropagatorSingle::getProbabilityArr. Will not work!");
-        }
+            return propagatorVector[deviceIndex]->getProbability(localCosineIndex, index_energy, t);
+          }
 
-    private:
+          void getProbabilityArr(FLOAT_T* probArr, ProbType t) {
+            throw std::runtime_error("CudaPropagatorSingle::getProbabilityArr. Will not work!");
+          }
 
-        void setMaxlayers() override{
+        private:
+
+          void setMaxlayers() override{
             Propagator<FLOAT_T>::setMaxlayers();
 
             for(auto& propagator : propagatorVector)
-                propagator->setMaxlayers();
-        }
+              propagator->setMaxlayers();
+          }
 
-        // get index in device id for the GPU which processes the index_cosine-th path
-        int getCosineDeviceIndex(int index_cosine){
-        #if 0
-                // block distribution
-                int id = 0;
-                for(int i = deviceIds.size(); i-- > 0;){
-                        if(index_cosine < (i+1) * n_cosines / deviceIds.size())
-                            id = i;
-                }
-        #else
-                // cyclic distribution.
-                const int id = index_cosine % deviceIds.size();
-        #endif
-                return id;
-        }
+          // get index in device id for the GPU which processes the index_cosine-th path
+          int getCosineDeviceIndex(int index_cosine){
+#if 0
+            // block distribution
+            int id = 0;
+            for(int i = deviceIds.size(); i-- > 0;){
+              if(index_cosine < (i+1) * n_cosines / deviceIds.size())
+                id = i;
+            }
+#else
+            // cyclic distribution.
+            const int id = index_cosine % deviceIds.size();
+#endif
+            return id;
+          }
 
-    private:
+        private:
 
-        std::vector<int> deviceIds;
-        std::vector<std::vector<int>> cosineIndices;
-        std::vector<int> localCosineIndices;
+          std::vector<int> deviceIds;
+          std::vector<std::vector<int>> cosineIndices;
+          std::vector<int> localCosineIndices;
 
-        std::vector<int> cosineBatches;
+          std::vector<int> cosineBatches;
 
-        // one CudaPropagatorSingle per GPU
-        std::vector<std::unique_ptr<CudaPropagatorSingle<FLOAT_T>>> propagatorVector;
-    };
+          // one CudaPropagatorSingle per GPU
+          std::vector<std::unique_ptr<CudaPropagatorSingle<FLOAT_T>>> propagatorVector;
+      };
 
 }
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -27,10 +27,10 @@ endif
 
 # Had to modify ptx assembler option
 all:
-	nvcc -g -O2 -x cu $(ARCH) -lineinfo -std=c++11 -Xcompiler="-fopenmp -Wall" -I.. main.cpp -o maingpu
+	nvcc -g -O0 -x cu $(ARCH) -lineinfo -std=c++11 -Xcompiler="-fopenmp -Wall" -I.. main.cpp -o maingpu
 
 cpu:
-	g++ -g -O2 -std=c++11 -fopenmp -Wall -I.. main.cpp -o maincpu
+	g++ -g -O0 -std=c++11 -fopenmp -Wall -I.. main.cpp -o maincpu
 
 clean:
 	rm -f maingpu maincpu

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -31,161 +31,163 @@ using namespace cudaprob3; // namespace of the propagators
 
 template<class T>
 std::vector<T> linspace(T Emin,T Emax,unsigned int div){
-    if(div==0)
-        throw std::length_error("div == 0");
+  if(div==0)
+    throw std::length_error("div == 0");
 
-    std::vector<T> linpoints(div, 0.0);
+  std::vector<T> linpoints(div, 0.0);
 
-    T step_lin = (Emax - Emin)/T(div-1);
+  T step_lin = (Emax - Emin)/T(div-1);
 
-    T EE = Emin;
+  T EE = Emin;
 
-    for(unsigned int i=0; i<div-1; i++, EE+=step_lin)
-        linpoints[i] = EE;
+  for(unsigned int i=0; i<div-1; i++, EE+=step_lin)
+    linpoints[i] = EE;
 
-    linpoints[div-1] = Emax;
+  linpoints[div-1] = Emax;
 
-    return linpoints;
+  return linpoints;
 }
 
 template<class T>
 std::vector<T> logspace(T Emin,T Emax,unsigned int div){
-    if(div==0)
-        throw std::length_error("div == 0");
-    std::vector<T> logpoints(div, 0.0);
+  if(div==0)
+    throw std::length_error("div == 0");
+  std::vector<T> logpoints(div, 0.0);
 
-    T Emin_log,Emax_log;
-    Emin_log = log(Emin);
-    Emax_log = log(Emax);
+  T Emin_log,Emax_log;
+  Emin_log = log(Emin);
+  Emax_log = log(Emax);
 
-    T step_log = (Emax_log - Emin_log)/T(div-1);
+  T step_log = (Emax_log - Emin_log)/T(div-1);
 
-    logpoints[0]=Emin;
-    T EE = Emin_log+step_log;
-    for(unsigned int i=1; i<div-1; i++, EE+=step_log)
-        logpoints[i] = exp(EE);
-    logpoints[div-1]=Emax;
-    return logpoints;
+  logpoints[0]=Emin;
+  T EE = Emin_log+step_log;
+  for(unsigned int i=1; i<div-1; i++, EE+=step_log)
+    logpoints[i] = exp(EE);
+  logpoints[div-1]=Emax;
+  return logpoints;
 }
 
 
 int main(int argc, char** argv){
 
-  using FLOAT_T = double;
-  //using FLOAT_T = float;
+  //using FLOAT_T = double;
+  using FLOAT_T = float;
 
-    TIMERSTARTCPU(total_runtime_with_output)
+  TIMERSTARTCPU(total_runtime_with_output);
 
-	//// Binning
-    int n_cosines = 200;
-    int n_energies = 200;
-    //int n_threads = 4;
+  //// Binning
+  int n_cosines = 200;
+  int n_energies = 200;
+  int n_threads = 1;
 
-    if(argc > 1)
-	n_cosines = std::atoi(argv[1]);
-    if(argc > 2)
-        n_energies = std::atoi(argv[2]);
-    //if(argc > 3)
-    //	n_threads = std::atoi(argv[3]);
+  if(argc > 1)
+    n_cosines = std::atoi(argv[1]);
+  if(argc > 2)
+    n_energies = std::atoi(argv[2]);
+  //if(argc > 3)
+  //	n_threads = std::atoi(argv[3]);
 
-    std::vector<FLOAT_T> cosineList = linspace((FLOAT_T)-1.0, (FLOAT_T)0.0, n_cosines);
-    std::vector<FLOAT_T> energyList = logspace((FLOAT_T)1.e0, (FLOAT_T)1.e2, n_energies);
+  std::vector<FLOAT_T> cosineList = linspace((FLOAT_T)-1.0, (FLOAT_T)0.0, n_cosines);
+  std::vector<FLOAT_T> energyList = logspace((FLOAT_T)1.e0, (FLOAT_T)1.e2, n_energies);
 
-    // Prob3++ probRoot.cc parameters in radians
-	const FLOAT_T theta12 = 0.5695951908800630486710466089860865317151404697548723;
-	const FLOAT_T theta13 = 0.1608752771983210967007023071793306595103776477788280;
-	const FLOAT_T theta23 = 0.7853981633974483096156608458198757210492923498437764;
-	const FLOAT_T dcp     = 0.0;
+  // Prob3++ probRoot.cc parameters in radians
+  const FLOAT_T theta12 = 0.5695951908800630486710466089860865317151404697548723;
+  const FLOAT_T theta13 = 0.1608752771983210967007023071793306595103776477788280;
+  const FLOAT_T theta23 = 0.7853981633974483096156608458198757210492923498437764;
+  const FLOAT_T dcp     = 0.0;
 
-	const FLOAT_T dm12sq = 7.9e-5;
-	const FLOAT_T dm23sq = 2.5e-3;
-	
-	//std::unique_ptr<Propagator<FLOAT_T>> propagator( new CpuPropagator<FLOAT_T>(n_cosines, n_energies, n_threads)); // cpu propagator with 4 threads
+  const FLOAT_T dm12sq = 7.9e-5;
+  const FLOAT_T dm23sq = 2.5e-3;
 
-    // these 3 are only available if compiled with nvcc.
+  //std::unique_ptr<Propagator<FLOAT_T>> propagator( new CpuPropagator<FLOAT_T>(n_cosines, n_energies, n_threads)); // cpu propagator with 4 threads
 
-	std::unique_ptr<Propagator<FLOAT_T>> propagator( new CudaPropagatorSingle<FLOAT_T>(0, n_cosines, n_energies)); // Single GPU propagator using GPU 0
-	//std::unique_ptr<Propagator<FLOAT_T>> propagator( new CudaPropagator<FLOAT_T>(std::vector<int>{0}, n_cosines, n_energies)); // Multi GPU propagator which only uses GPU 0. Behaves identical to propagator above.
-	//std::unique_ptr<Propagator<FLOAT_T>> propagator( new CudaPropagator<FLOAT_T>(std::vector<int>{0, 1, 2, 3}, n_cosines, n_energies)); // Multi GPU propagator which uses GPU 0 and GPU 1
+  // these 3 are only available if compiled with nvcc.
+
+  std::unique_ptr<Propagator<FLOAT_T>> propagator( new CudaPropagatorSingle<FLOAT_T>(0, n_cosines, n_energies)); // Single GPU propagator using GPU 0
+  //std::unique_ptr<Propagator<FLOAT_T>> propagator( new CudaPropagator<FLOAT_T>(std::vector<int>{0}, n_cosines, n_energies)); // Multi GPU propagator which only uses GPU 0. Behaves identical to propagator above.
+  //std::unique_ptr<Propagator<FLOAT_T>> propagator( new CudaPropagator<FLOAT_T>(std::vector<int>{0, 1, 2, 3}, n_cosines, n_energies)); // Multi GPU propagator which uses GPU 0 and GPU 1
 
 
-    // set energy list
-	propagator->setEnergyList(energyList);
+  // set energy list
+  propagator->setEnergyList(energyList);
 
-    //set cosine list
-	propagator->setCosineList(cosineList);
+  //set cosine list
+  propagator->setCosineList(cosineList);
 
-    // set mixing matrix. angles in radians
-	propagator->setMNSMatrix(theta12, theta13, theta23, dcp);
+  // set mixing matrix. angles in radians
+  propagator->setMNSMatrix(theta12, theta13, theta23, dcp);
 
-    // set neutrino mass differences. unit: eV^2
-	propagator->setNeutrinoMasses(dm12sq, dm23sq);
+  // set neutrino mass differences. unit: eV^2
+  propagator->setNeutrinoMasses(dm12sq, dm23sq);
 
-    // set density model
-    propagator->setDensityFromFile("models/PREM_12layer.dat");
+  // set density model
+  //propagator->setDensityFromFile("models/PREM_12layer.dat");
+  propagator->setDensityFromFile("../models/PREM_4layer_cubic.dat");
+  //propagator->setDensityFromFile("../models/PREM_4layer.dat");
 
-    // set neutrino production height in kilometers above earth
-    propagator->setProductionHeight(22.0);
+  // set neutrino production height in kilometers above earth
+  propagator->setProductionHeight(22.0);
+  propagator->SetNumberOfProductionHeightBinsForAveraging(1);
+  std::vector<FLOAT_T> prob;
+  std::vector<FLOAT_T> height;
+  for (int i = 0; i < 1*2*3*n_cosines*n_energies; ++i) {
+    prob.push_back(1.0);
+  }
+  height.push_back(22.0);
+  height.push_back(22.5);
+  propagator->setProductionHeightList(prob, height);
 
-    TIMERSTARTCPU(calc_and_transfer);
-    TIMERSTARTCPU(calculation);
+  TIMERSTARTCPU(calc_and_transfer);
+  TIMERSTARTCPU(calculation);
 
-    // perform calculation. parameter is either cudaprob3::Neutrino or cudaprob3::Antineutrino
-	propagator->calculateProbabilities(cudaprob3::Neutrino);
+  // perform calculation. parameter is either cudaprob3::Neutrino or cudaprob3::Antineutrino
+  propagator->calculateProbabilities(cudaprob3::Neutrino);
 
-    TIMERSTOPCPU(calculation);
-	//first result access after calculation triggers data transfer
-    propagator->getProbability(0,0, ProbType::e_e);
-    TIMERSTOPCPU(calc_and_transfer);
+
+  TIMERSTOPCPU(calculation);
+  //first result access after calculation triggers data transfer
+  propagator->getProbability(0,0, ProbType::e_e);
+  TIMERSTOPCPU(calc_and_transfer);
 
 #if 1
-    // write output to files
+  // write output to files
 
-	std::ofstream outfile00("out_e_e.txt");
-	std::ofstream outfile01("out_e_m.txt");
-	std::ofstream outfile02("out_e_t.txt");
-	std::ofstream outfile10("out_m_e.txt");
-	std::ofstream outfile11("out_m_m.txt");
-	std::ofstream outfile12("out_m_t.txt");
-	std::ofstream outfile20("out_t_e.txt");
-	std::ofstream outfile21("out_t_m.txt");
-	std::ofstream outfile22("out_t_t.txt");
+  std::ofstream outfile00("out_e_e.txt");
+  std::ofstream outfile01("out_e_m.txt");
+  std::ofstream outfile02("out_e_t.txt");
+  std::ofstream outfile10("out_m_e.txt");
+  std::ofstream outfile11("out_m_m.txt");
+  std::ofstream outfile12("out_m_t.txt");
+  std::ofstream outfile20("out_t_e.txt");
+  std::ofstream outfile21("out_t_m.txt");
+  std::ofstream outfile22("out_t_t.txt");
 
-    outfile00 << n_cosines << " " << n_energies <<'\n';
-    outfile01 << n_cosines << " " << n_energies <<'\n';
-    outfile02 << n_cosines << " " << n_energies <<'\n';
-    outfile10 << n_cosines << " " << n_energies <<'\n';
-    outfile11 << n_cosines << " " << n_energies <<'\n';
-    outfile12 << n_cosines << " " << n_energies <<'\n';
-    outfile20 << n_cosines << " " << n_energies <<'\n';
-    outfile21 << n_cosines << " " << n_energies <<'\n';
-    outfile22 << n_cosines << " " << n_energies <<'\n';
+  outfile00 << n_cosines << " " << n_energies <<'\n';
+  outfile01 << n_cosines << " " << n_energies <<'\n';
+  outfile02 << n_cosines << " " << n_energies <<'\n';
+  outfile10 << n_cosines << " " << n_energies <<'\n';
+  outfile11 << n_cosines << " " << n_energies <<'\n';
+  outfile12 << n_cosines << " " << n_energies <<'\n';
+  outfile20 << n_cosines << " " << n_energies <<'\n';
+  outfile21 << n_cosines << " " << n_energies <<'\n';
+  outfile22 << n_cosines << " " << n_energies <<'\n';
 
-    for(int i = 0; i < n_cosines; i++) {
-        for(int j = 0; j < n_energies; j++) {
+  for(int i = 0; i < n_cosines; i++) {
+    for(int j = 0; j < n_energies; j++) {
 
-            // ProbType::x_y is probability of transition x -> y
-            outfile00 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::e_e) << " ";
-            outfile01 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::e_m) << " ";
-            outfile02 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::e_t) << " ";
-            outfile10 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::m_e) << " ";
-            outfile11 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::m_m) << " ";
-            outfile12 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::m_t) << " ";
-            outfile20 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::t_e) << " ";
-            outfile21 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::t_m) << " ";
-            outfile22 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::t_t) << " ";
-		}
+      // ProbType::x_y is probability of transition x -> y
+      outfile00 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::e_e) << " ";
+      outfile01 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::e_m) << " ";
+      outfile02 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::e_t) << " ";
+      outfile10 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::m_e) << " ";
+      outfile11 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::m_m) << " ";
+      outfile12 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::m_t) << " ";
+      outfile20 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::t_e) << " ";
+      outfile21 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::t_m) << " ";
+      outfile22 << std::setprecision(20) << propagator->getProbability(i, j, ProbType::t_t) << " ";
+    }
 
-		outfile00 << '\n';
-		outfile01 << '\n';
-		outfile02 << '\n';
-		outfile10 << '\n';
-		outfile11 << '\n';
-		outfile12 << '\n';
-		outfile20 << '\n';
-		outfile21 << '\n';
-		outfile22 << '\n';
-	}
     outfile00 << '\n';
     outfile01 << '\n';
     outfile02 << '\n';
@@ -195,19 +197,29 @@ int main(int argc, char** argv){
     outfile20 << '\n';
     outfile21 << '\n';
     outfile22 << '\n';
+  }
+  outfile00 << '\n';
+  outfile01 << '\n';
+  outfile02 << '\n';
+  outfile10 << '\n';
+  outfile11 << '\n';
+  outfile12 << '\n';
+  outfile20 << '\n';
+  outfile21 << '\n';
+  outfile22 << '\n';
 
-	outfile00.flush();
-	outfile01.flush();
-	outfile02.flush();
-	outfile10.flush();
-	outfile11.flush();
-	outfile12.flush();
-	outfile20.flush();
-	outfile21.flush();
-	outfile22.flush();
+  outfile00.flush();
+  outfile01.flush();
+  outfile02.flush();
+  outfile10.flush();
+  outfile11.flush();
+  outfile12.flush();
+  outfile20.flush();
+  outfile21.flush();
+  outfile22.flush();
 
 #endif
 
-    TIMERSTOPCPU(total_runtime_with_output)
+  TIMERSTOPCPU(total_runtime_with_output)
 
 }

--- a/models/PREM_4layer_cubic.dat
+++ b/models/PREM_4layer_cubic.dat
@@ -4,9 +4,9 @@
 # Idea by Lukas Berns, and http://www.typnet.net/Essays/EarthGravGraphics/EarthGrav.pdf
 # Could also implemened the more detailed polynomials from table 1 of PREM paper (https://doi.org/10.1016/0031-9201(81)90046-7)
 
-#radius  a           b           c        Yp
-0.      -2.1773e-10  1.9110e-8   1.3088e4 0.468
-1220.0  -2.1773e-10  1.9110e-8   1.3088e4 0.468
-3480.0  -2.4123e-10  1.3976e-4   1.2346e4 0.468
-5701.0  -3.0922e-11  -2.4441e-4  6.7823e3 0.497
-6371.0  0            -1.2603e-3  1.1249e4 0.497
+#radius  a          b           c         Yp
+0.      -2.1773e-7  1.9110e-8   1.3088e1  0.468
+1220.0  -2.1773e-7  1.9110e-8   1.3088e1  0.468
+3480.0  -2.4123e-7  1.3976e-4   1.2346e1  0.468
+5701.0  -3.0922e-8  -2.4441e-4  6.7823e0  0.497
+6371.0  0           -1.2603e-3  1.1249e1  0.497

--- a/models/PREM_4layer_cubic.dat
+++ b/models/PREM_4layer_cubic.dat
@@ -1,0 +1,12 @@
+# PREM 4 layer, but using cubic polynomial for the density in each layer
+# Improves on PREM 4 by not assuming constant density in each layer
+# Cubic polynomial has form density = a r^2 + b r + c
+# Idea by Lukas Berns, and http://www.typnet.net/Essays/EarthGravGraphics/EarthGrav.pdf
+# Could also implemened the more detailed polynomials from table 1 of PREM paper (https://doi.org/10.1016/0031-9201(81)90046-7)
+
+#radius  a           b           c        Yp
+0.      -2.1773e-10  1.9110e-8   1.3088e4 0.468
+1220.0  -2.1773e-10  1.9110e-8   1.3088e4 0.468
+3480.0  -2.4123e-10  1.3976e-4   1.2346e4 0.468
+5701.0  -3.0922e-11  -2.4441e-4  6.7823e3 0.497
+6371.0  0            -1.2603e-3  1.1249e4 0.497

--- a/physics.hpp
+++ b/physics.hpp
@@ -1152,6 +1152,9 @@ namespace cudaprob3{
                 const FLOAT_T* const energylist,
                 int n_energies,
                 const FLOAT_T* const radii,
+                const FLOAT_T* const as,
+                const FLOAT_T* const bs,
+                const FLOAT_T* const cs,
                 const FLOAT_T* const rhos,
                 const FLOAT_T* const yps,
                 const int* const maxlayers,
@@ -1162,12 +1165,32 @@ namespace cudaprob3{
                 const FLOAT_T* const productionHeight_binedges_list,
                 FLOAT_T* const result){
 
+              /*
               calculate(type, 
                   cosinelist, 
                   n_cosines, 
                   energylist, 
                   n_energies, 
                   radii, 
+                  rhos, 
+                  yps, 
+                  maxlayers, 
+                  ProductionHeightinCentimeter, 
+                  useProductionHeightAveraging, 
+                  nProductionHeightBins, 
+                  productionHeight_prob_list, 
+                  productionHeight_binedges_list, 
+                  result);
+                  */
+              calculate(type, 
+                  cosinelist, 
+                  n_cosines, 
+                  energylist, 
+                  n_energies, 
+                  radii, 
+                  as,
+                  bs,
+                  cs,
                   rhos, 
                   yps, 
                   maxlayers, 
@@ -1189,6 +1212,9 @@ namespace cudaprob3{
                 const FLOAT_T* const energylist,
                 int n_energies,
                 const FLOAT_T* const radii,
+                const FLOAT_T* const as,
+                const FLOAT_T* const bs,
+                const FLOAT_T* const cs,
                 const FLOAT_T* const rhos,
                 const FLOAT_T* const yps,
                 const int* const maxlayers,
@@ -1201,7 +1227,42 @@ namespace cudaprob3{
 
               prepare_getMfast<FLOAT_T>(type);
 
-              calculateKernel<FLOAT_T><<<grid, block, 0, stream>>>(type, cosinelist, n_cosines, energylist, n_energies, radii, rhos, yps, maxlayers, ProductionHeightinCentimeter, useProductionHeightAveraging, nProductionHeightBins, productionHeight_prob_list, productionHeight_binedges_list,  result);
+              /*
+              calculateKernel<FLOAT_T><<<grid, block, 0, stream>>>(
+                  type, 
+                  cosinelist, 
+                  n_cosines, 
+                  energylist, 
+                  n_energies, 
+                  radii, 
+                  rhos, 
+                  yps, 
+                  maxlayers, 
+                  ProductionHeightinCentimeter, 
+                  useProductionHeightAveraging, 
+                  nProductionHeightBins, 
+                  productionHeight_prob_list, 
+                  productionHeight_binedges_list,  
+                  result);
+              CUERR;
+              */
+              calculateKernel<FLOAT_T><<<grid, block, 0, stream>>>(
+                  type, 
+                  cosinelist, 
+                  n_cosines, 
+                  energylist, 
+                  n_energies, 
+                  radii, 
+                  as, bs, cs,
+                  rhos, 
+                  yps, 
+                  maxlayers, 
+                  ProductionHeightinCentimeter, 
+                  useProductionHeightAveraging, 
+                  nProductionHeightBins, 
+                  productionHeight_prob_list, 
+                  productionHeight_binedges_list,  
+                  result);
               CUERR;
             }
 #endif

--- a/physics.hpp
+++ b/physics.hpp
@@ -106,1046 +106,1109 @@ along with CUDAProb3++.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace cudaprob3{
 
-        namespace physics{
+  namespace physics{
 
-            /*
-            * Constant global data
-            */
+    /*
+     * Constant global data
+     */
 
-            #ifdef __NVCC__
-                __constant__ double mix_data_device [9 * sizeof(math::ComplexNumber<double>)] ;
-                __constant__ double mass_data_device[9];
-                __constant__ double A_X_factor_device[81 * 4]; //precomputed factors which only depend on the mixing matrix for faster calculation
-                __constant__ int mass_order_device[3];
-            #endif
+#ifdef __NVCC__
+    __constant__ double mix_data_device [9 * sizeof(math::ComplexNumber<double>)] ;
+    __constant__ double mass_data_device[9];
+    __constant__ double A_X_factor_device[81 * 4]; //precomputed factors which only depend on the mixing matrix for faster calculation
+    __constant__ int mass_order_device[3];
+#endif
 
-            static double mix_data [9 * sizeof(math::ComplexNumber<double>)] ;
-            static double mass_data[9];
-            static double A_X_factor[81 * 4]; //precomputed factors for faster calculation
-            static int mass_order[3];
+    static double mix_data [9 * sizeof(math::ComplexNumber<double>)] ;
+    static double mass_data[9];
+    static double A_X_factor[81 * 4]; //precomputed factors for faster calculation
+    static int mass_order[3];
 
-            /*
-             * Set global 3x3 pmns mixing matrix
-             */
-            template<typename FLOAT_T>
-            void setMixMatrix(math::ComplexNumber<FLOAT_T>* U){
-                memcpy((FLOAT_T*)mix_data, U, sizeof(math::ComplexNumber<FLOAT_T>) * 9);
+    /*
+     * Set global 3x3 pmns mixing matrix
+     */
+    template<typename FLOAT_T>
+      void setMixMatrix(math::ComplexNumber<FLOAT_T>* U){
+        memcpy((FLOAT_T*)mix_data, U, sizeof(math::ComplexNumber<FLOAT_T>) * 9);
 
-                //precomputed factors for faster calculation
-                for (int n=0; n<3; n++) {
-                    for (int m=0; m<3; m++) {
-                        for (int i=0; i<3; i++) {
-                            for (int j=0; j<3; j++) {
-                                AXFAC(n,m,i,j,0) = U[n * 3 + i].re * U[m * 3 + j].re + U[n * 3 + i].im * U[m * 3 + j].im;
-                                AXFAC(n,m,i,j,1) = U[n * 3 + i].re * U[m * 3 + j].im - U[n * 3 + i].im * U[m * 3 + j].re;
-                                AXFAC(n,m,i,j,2) = U[n * 3 + i].im * U[m * 3 + j].im + U[n * 3 + i].re * U[m * 3 + j].re;
-                                AXFAC(n,m,i,j,3) = U[n * 3 + i].im * U[m * 3 + j].re - U[n * 3 + i].re * U[m * 3 + j].im;
-                            }
-                        }
-                    }
-                }
-                #ifdef __NVCC__
-                    //copy to constant memory on GPU
-                    cudaMemcpyToSymbol(mix_data_device, U, sizeof(math::ComplexNumber<FLOAT_T>) * 9, 0, H2D); CUERR;
-                    cudaMemcpyToSymbol(A_X_factor_device, A_X_factor, sizeof(FLOAT_T) * 81 * 4, 0, H2D); CUERR;
-                #endif
-            }
-
-            /*
-             * Set global 3x3 pmns mixing matrix on host only
-             */
-            template<typename FLOAT_T>
-            void setMixMatrix_host(math::ComplexNumber<FLOAT_T>* U){
-                memcpy((FLOAT_T*)mix_data, U, sizeof(math::ComplexNumber<FLOAT_T>) * 9);
-
-                //precomputed factors for faster calculation
-                for (int n=0; n<3; n++) {
-                    for (int m=0; m<3; m++) {
-                        for (int i=0; i<3; i++) {
-                            for (int j=0; j<3; j++) {
-                                AXFAC(n,m,i,j,0) = U[n * 3 + i].re * U[m * 3 + j].re + U[n * 3 + i].im * U[m * 3 + j].im;
-                                AXFAC(n,m,i,j,1) = U[n * 3 + i].re * U[m * 3 + j].im - U[n * 3 + i].im * U[m * 3 + j].re;
-                                AXFAC(n,m,i,j,2) = U[n * 3 + i].im * U[m * 3 + j].im + U[n * 3 + i].re * U[m * 3 + j].re;
-                                AXFAC(n,m,i,j,3) = U[n * 3 + i].im * U[m * 3 + j].re - U[n * 3 + i].re * U[m * 3 + j].im;
-                            }
-                        }
-                    }
-                }
-            }
-
-            /*
-             * Set global 3x3 neutrino mass difference matrix
-             */
-            /// \brief set mass differences to constant memory
-            template<typename FLOAT_T>
-            void setMassDifferences(FLOAT_T* dm){
-                memcpy((FLOAT_T*)mass_data, dm, sizeof(FLOAT_T) * 9);
-                #ifdef __NVCC__
-                cudaMemcpyToSymbol(mass_data_device, dm, sizeof(FLOAT_T) * 9 , 0, cudaMemcpyHostToDevice); CUERR;
-                #endif
-            }
-
-            /*
-             * Set global 3x3 neutrino mass difference matrix on host only
-             */
-            template<typename FLOAT_T>
-            void setMassDifferences_host(FLOAT_T* dm){
-                memcpy((FLOAT_T*)mass_data, dm, sizeof(FLOAT_T) * 9);
-            }
-
-
-            //
-            template<typename FLOAT_T>
-            void prepare_getMfast(NeutrinoType type) {
-                FLOAT_T alphaV, betaV, gammaV, argV, tmpV;
-                FLOAT_T theta0V, theta1V, theta2V;
-                FLOAT_T mMatV[3];
-
-                /* The strategy to sort out the three roots is to compute the vacuum
-                * mass the same way as the "matter" masses are computed then to sort
-                * the results according to the input vacuum masses
-                */
-                alphaV = DM(0,1) + DM(0,2);
-
-                betaV = DM(0,1) * DM(0,2);
-
-                gammaV = 0.0;
-
-                /* Compute the argument of the arc-cosine */
-                tmpV = alphaV*alphaV-3.0*betaV;
-
-                /* Equation (21) */
-                argV = (2.0*alphaV*alphaV*alphaV-9.0*alphaV*betaV+27.0*gammaV)/
-                    (2.0*sqrt(tmpV*tmpV*tmpV));
-                if (fabs(argV)>1.0) argV = argV/fabs(argV);
-
-                /* These are the three roots the paper refers to */
-                theta0V = acos(argV)/3.0;
-                theta1V = theta0V-(2.0*M_PI/3.0);
-                theta2V = theta0V+(2.0*M_PI/3.0);
-
-                mMatV[0] = mMatV[1] = mMatV[2] = -(2.0/3.0)*sqrt(tmpV);
-                mMatV[0] *= cos(theta0V); mMatV[1] *= cos(theta1V); mMatV[2] *= cos(theta2V);
-                tmpV = DM(0,0) - alphaV/3.0;
-                mMatV[0] += tmpV; mMatV[1] += tmpV; mMatV[2] += tmpV;
-
-                /* Sort according to which reproduce the vaccum eigenstates */
-                int order[3];
-
-                for (int i=0; i<3; i++) {
-                    tmpV = fabs(DM(i,0)-mMatV[0]);
-                    int k = 0;
-
-                    for (int j=1; j<3; j++) {
-                        FLOAT_T tmp = fabs(DM(i,0)-mMatV[j]);
-                        if (tmp<tmpV) {
-                            k = j;
-                            tmpV = tmp;
-                        }
-                    }
-                    order[i] = k;
-                }
-                memcpy(mass_order, order, sizeof(int) * 3);
-
-                #ifdef __NVCC__
-                cudaMemcpyToSymbol(mass_order_device, order, sizeof(int) * 3, 0, cudaMemcpyHostToDevice); CUERR;
-                #endif
-            }
-
-           /*
-            * Return induced neutrino mass difference matrix d_dmMatMat,
-            * and d_dmMatVac, which is the mass difference matrix between induced masses and vacuum masses
-            *
-            * The strategy to sort out the three roots is to compute the vacuum
-            * mass the same way as the "matter" masses are computed then to sort
-            * the results according to the input vacuum masses. Subsequently, the "matter" masses
-            * are calculated, using the found sorting for vacuum masses
-            *
-            * In the original implementation the order of vacuum masses is computed for each bin.
-            * However, the ordering of vacuum masses does only depend on the constant neutrino mixing matrix.
-            * Thus, the ordering can be precomputed, which is done in prepare_getMfast
-            */
-            template<typename FLOAT_T>
-            HOSTDEVICEQUALIFIER
-            void getMfast(const FLOAT_T Enu, const FLOAT_T rho,
-                const NeutrinoType type,
-                FLOAT_T d_dmMatMat[][3], FLOAT_T d_dmMatVac[][3]) {
-
-                FLOAT_T mMatU[3], mMat[3];
-
-                /* Equations (22) fro Barger et.al.*/
-                const FLOAT_T fac = [&](){
-                    if(type == Antineutrino)
-		      return Constants<FLOAT_T>::tworttwoGf()*Enu*rho;
-                    else
-		      return -Constants<FLOAT_T>::tworttwoGf()*Enu*rho;
-                }();
-
-                const FLOAT_T alpha  = fac + DM(0,1) + DM(0,2);
-
-                const FLOAT_T beta = DM(0,1)*DM(0,2) +
-                    fac*(DM(0,1)*(1.0 -
-                            U(0,1).re*U(0,1).re -
-                            U(0,1).im*U(0,1).im ) +
-                    DM(0,2)*(1.0-
-                            U(0,2).re*U(0,2).re -
-                            U(0,2).im*U(0,2).im));
-
-
-                const FLOAT_T gamma = fac*DM(0,1)*DM(0,2)*(U(0,0).re * U(0,0).re + U(0,0).im * U(0,0).im);
-
-                /* Compute the argument of the arc-cosine */
-                const FLOAT_T tmp = alpha*alpha-3.0*beta < 0 ? 0 : alpha*alpha-3.0*beta;
-
-                /* Equation (21) */
-                const FLOAT_T argtmp = (2.0*alpha*alpha*alpha-9.0*alpha*beta+27.0*gamma)/
-                    (2.0*sqrt(tmp*tmp*tmp));
-                const FLOAT_T arg = [&](){
-                    if (fabs(argtmp)>1.0)
-                        return argtmp/fabs(argtmp);
-                    else
-                        return argtmp;
-                }();
-
-                /* These are the three roots the paper refers to */
-                const FLOAT_T theta0 = acos(arg)/3.0;
-                const FLOAT_T theta1 = theta0-(2.0*M_PI/3.0);
-                const FLOAT_T theta2 = theta0+(2.0*M_PI/3.0);
-
-                mMatU[0] = -(2.0/3.0)*sqrt(tmp);
-                mMatU[1] = -(2.0/3.0)*sqrt(tmp);
-                mMatU[2] = -(2.0/3.0)*sqrt(tmp);
-                mMatU[0] *= cos(theta0);
-                mMatU[1] *= cos(theta1);
-                mMatU[2] *= cos(theta2);
-                const FLOAT_T tmp2 = DM(0,0) - alpha/3.0;
-                mMatU[0] += tmp2;
-                mMatU[1] += tmp2;
-                mMatU[2] += tmp2;
-
-                /* Sort according to which reproduce the vaccum eigenstates */
-
-                UNROLLQUALIFIER
-                for (int i=0; i<3; i++) {
-                    mMat[i] = mMatU[ORDER(i)];
-                }
-
-                UNROLLQUALIFIER
-                for (int i=0; i<3; i++) {
-                    UNROLLQUALIFIER
-                    for (int j=0; j<3; j++) {
-                        d_dmMatMat[i][j] = mMat[i] - mMat[j];
-                        d_dmMatVac[i][j] = mMat[i] - DM(j,0);
-                    }
-                }
-            }
-
-            /*
-                Calculate the product of Eq. (11)
-            */
-            template<typename FLOAT_T>
-            HOSTDEVICEQUALIFIER
-            void get_product(const FLOAT_T L, const FLOAT_T E, const FLOAT_T rho, const FLOAT_T d_dmMatVac[][3], const FLOAT_T d_dmMatMat[][3],
-                const NeutrinoType type, math::ComplexNumber<FLOAT_T> product[][3][3]){
-
-                math::ComplexNumber<FLOAT_T> twoEHmM[3][3][3];
-
-                const FLOAT_T fac = [&](){
-                    if(type == Antineutrino)
-                        return Constants<FLOAT_T>::tworttwoGf()*E*rho;
-                    else
-                        return -Constants<FLOAT_T>::tworttwoGf()*E*rho;
-                }();
-
-                /* Calculate the matrix 2EH-M_j */
-                UNROLLQUALIFIER
-                for (int n=0; n<3; n++) {
-                    UNROLLQUALIFIER
-                    for (int m=0; m<3; m++) {
-                        twoEHmM[n][m][0].re = -fac*(U(0,n).re*U(0,m).re+U(0,n).im*U(0,m).im);
-                        twoEHmM[n][m][0].im = -fac*(U(0,n).re*U(0,m).im-U(0,n).im*U(0,m).re);
-                        twoEHmM[n][m][1].re = -fac*(U(0,n).re*U(0,m).re+U(0,n).im*U(0,m).im);
-                        twoEHmM[n][m][1].im = -fac*(U(0,n).re*U(0,m).im-U(0,n).im*U(0,m).re);
-                        twoEHmM[n][m][2].re = -fac*(U(0,n).re*U(0,m).re+U(0,n).im*U(0,m).im);
-                        twoEHmM[n][m][2].im = -fac*(U(0,n).re*U(0,m).im-U(0,n).im*U(0,m).re);
-                    }
-                }
-
-                UNROLLQUALIFIER
-                for (int j=0; j<3; j++){
-                    twoEHmM[0][0][j].re-= d_dmMatVac[j][0];
-                    twoEHmM[1][1][j].re-= d_dmMatVac[j][1];
-                    twoEHmM[2][2][j].re-= d_dmMatVac[j][2];
-                }
-
-                /* Calculate the product in eq.(11) of twoEHmM for j!=k */
-                //memset(product, 0, 3*3*3*sizeof(math::ComplexNumber<FLOAT_T>));
-                UNROLLQUALIFIER
-                for (int i=0; i<3; i++) {
-                    UNROLLQUALIFIER
-                    for (int j=0; j<3; j++) {
-                        UNROLLQUALIFIER
-                        for (int k=0; k<3; k++) {
-                            product[i][j][k].re = 0;
-                            product[i][j][k].im = 0;
-                        }
-                    }
-                }
-
-                UNROLLQUALIFIER
-                for (int i=0; i<3; i++) {
-                    UNROLLQUALIFIER
-                    for (int j=0; j<3; j++) {
-                        UNROLLQUALIFIER
-                        for (int k=0; k<3; k++) {
-                            product[i][j][0].re +=
-                                twoEHmM[i][k][1].re*twoEHmM[k][j][2].re -
-                                twoEHmM[i][k][1].im*twoEHmM[k][j][2].im;
-                            product[i][j][0].im +=
-                                twoEHmM[i][k][1].re*twoEHmM[k][j][2].im +
-                                twoEHmM[i][k][1].im*twoEHmM[k][j][2].re;
-
-                            product[i][j][1].re +=
-                                twoEHmM[i][k][2].re*twoEHmM[k][j][0].re -
-                                twoEHmM[i][k][2].im*twoEHmM[k][j][0].im;
-                            product[i][j][1].im +=
-                                twoEHmM[i][k][2].re*twoEHmM[k][j][0].im +
-                                twoEHmM[i][k][2].im*twoEHmM[k][j][0].re;
-
-                            product[i][j][2].re +=
-                                twoEHmM[i][k][0].re*twoEHmM[k][j][1].re -
-                                twoEHmM[i][k][0].im*twoEHmM[k][j][1].im;
-                            product[i][j][2].im +=
-                                twoEHmM[i][k][0].re*twoEHmM[k][j][1].im +
-                                twoEHmM[i][k][0].im*twoEHmM[k][j][1].re;
-                        }
-
-                        product[i][j][0].re /= (d_dmMatMat[0][1]*d_dmMatMat[0][2]);
-                        product[i][j][0].im /= (d_dmMatMat[0][1]*d_dmMatMat[0][2]);
-                        product[i][j][1].re /= (d_dmMatMat[1][2]*d_dmMatMat[1][0]);
-                        product[i][j][1].im /= (d_dmMatMat[1][2]*d_dmMatMat[1][0]);
-                        product[i][j][2].re /= (d_dmMatMat[2][0]*d_dmMatMat[2][1]);
-                        product[i][j][2].im /= (d_dmMatMat[2][0]*d_dmMatMat[2][1]);
-                    }
-                }
-            }
-	  
-	  /***********************************************************************
-  getArg
-  
-  Transition matrix expanded as A = sum_k C_k exp(i arg_k).
-  This function returns arg, whereas getC returns C.
-  arg has index [k], where k is this expansion index.
-	  ***********************************************************************/
-          template<typename FLOAT_T>
-          HOSTDEVICEQUALIFIER
-	  void getArg(const FLOAT_T L, const FLOAT_T E, const FLOAT_T dmMatVac[][3], const FLOAT_T phase_offset, FLOAT_T arg[3]) {
-
-	    /* (1/2)*(1/(h_bar*c)) in units of GeV/(eV^2-km) */
-	    const FLOAT_T LoEfac = 2.534;
-
-	    for (int k=0; k<3; k++) {
-	      arg[k] = -LoEfac*dmMatVac[k][0]*L/E;
-	      if ( k==2 ) arg[k] += phase_offset ;
-	    }
-	  }
-	  
-	  /***********************************************************************
-  getC
-  
-  Transition matrix expanded as A = sum_k C_k exp(i arg_k).
-  This function returns C, whereas getArg returns arg.
-  C_{re,im} have indices [k][row][col] where k is this expansion index.
-	  ***********************************************************************/
-          template<typename FLOAT_T>
-          HOSTDEVICEQUALIFIER
-          void getC(FLOAT_T E, FLOAT_T rho, FLOAT_T dmMatVac[][3], FLOAT_T dmMatMat[][3],
-		    cudaprob3::NeutrinoType type, FLOAT_T phase_offset, math::ComplexNumber<FLOAT_T> C[3][3][3]) {
-		    
-	    const int nExp = 3;
-	    const int nNuFlav = 3;
-	  
-	    math::ComplexNumber<FLOAT_T> product[nNuFlav][nNuFlav][nExp];
-
-            if (phase_offset == 0.0) {
-	      FLOAT_T L = NAN;
-              get_product(L, E, rho, dmMatVac, dmMatMat, type, product);
-            }
-
-            /* Compute the product with the mixing matrices */
-            for (int iExp=0;iExp<nNuFlav;iExp++) {
-              for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-
-                FLOAT_T RR_nk[nNuFlav] = { 0., 0., 0. };
-                FLOAT_T RI_nk[nNuFlav] = { 0., 0., 0. };
-                FLOAT_T IR_nk[nNuFlav] = { 0., 0., 0. };
-                FLOAT_T II_nk[nNuFlav] = { 0., 0., 0. };
-
-                for (int i=0; i<nNuFlav; i++) {
-                  for (int j=0; j<nNuFlav; j++) {
-                    RR_nk[j] += U(iNuFlav,i).re * product[i][j][iExp].re;
-                    RI_nk[j] += U(iNuFlav,i).re * product[i][j][iExp].im;
-                    IR_nk[j] += U(iNuFlav,i).im * product[i][j][iExp].re;
-                    II_nk[j] += U(iNuFlav,i).im * product[i][j][iExp].im;
-                  }
-                }
-
-                for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) {
-                  FLOAT_T ReSum=0., ImSum=0.;
-
-                  for (int j=0; j<nNuFlav; j++) {
-                    ReSum += RR_nk[j] * U(jNuFlav,j).re;
-                    ReSum += RI_nk[j] * U(jNuFlav,j).im;
-                    ReSum += IR_nk[j] * U(jNuFlav,j).im;
-                    ReSum -= II_nk[j] * U(jNuFlav,j).re;
-
-                    ImSum += II_nk[j] * U(jNuFlav,j).im;
-                    ImSum += IR_nk[j] * U(jNuFlav,j).re;
-                    ImSum += RI_nk[j] * U(jNuFlav,j).re;
-                    ImSum -= RR_nk[j] * U(jNuFlav,j).im;
-                  }
-		
-                  C[iExp][iNuFlav][jNuFlav].re = ReSum;
-                  C[iExp][iNuFlav][jNuFlav].im = ImSum;
-
-                }
+        //precomputed factors for faster calculation
+        for (int n=0; n<3; n++) {
+          for (int m=0; m<3; m++) {
+            for (int i=0; i<3; i++) {
+              for (int j=0; j<3; j++) {
+                AXFAC(n,m,i,j,0) = U[n * 3 + i].re * U[m * 3 + j].re + U[n * 3 + i].im * U[m * 3 + j].im;
+                AXFAC(n,m,i,j,1) = U[n * 3 + i].re * U[m * 3 + j].im - U[n * 3 + i].im * U[m * 3 + j].re;
+                AXFAC(n,m,i,j,2) = U[n * 3 + i].im * U[m * 3 + j].im + U[n * 3 + i].re * U[m * 3 + j].re;
+                AXFAC(n,m,i,j,3) = U[n * 3 + i].im * U[m * 3 + j].re - U[n * 3 + i].re * U[m * 3 + j].im;
               }
             }
-	        
+          }
+        }
+#ifdef __NVCC__
+        //copy to constant memory on GPU
+        cudaMemcpyToSymbol(mix_data_device, U, sizeof(math::ComplexNumber<FLOAT_T>) * 9, 0, H2D); CUERR;
+        cudaMemcpyToSymbol(A_X_factor_device, A_X_factor, sizeof(FLOAT_T) * 81 * 4, 0, H2D); CUERR;
+#endif
+      }
+
+    /*
+     * Set global 3x3 pmns mixing matrix on host only
+     */
+    template<typename FLOAT_T>
+      void setMixMatrix_host(math::ComplexNumber<FLOAT_T>* U){
+        memcpy((FLOAT_T*)mix_data, U, sizeof(math::ComplexNumber<FLOAT_T>) * 9);
+
+        //precomputed factors for faster calculation
+        for (int n=0; n<3; n++) {
+          for (int m=0; m<3; m++) {
+            for (int i=0; i<3; i++) {
+              for (int j=0; j<3; j++) {
+                AXFAC(n,m,i,j,0) = U[n * 3 + i].re * U[m * 3 + j].re + U[n * 3 + i].im * U[m * 3 + j].im;
+                AXFAC(n,m,i,j,1) = U[n * 3 + i].re * U[m * 3 + j].im - U[n * 3 + i].im * U[m * 3 + j].re;
+                AXFAC(n,m,i,j,2) = U[n * 3 + i].im * U[m * 3 + j].im + U[n * 3 + i].re * U[m * 3 + j].re;
+                AXFAC(n,m,i,j,3) = U[n * 3 + i].im * U[m * 3 + j].re - U[n * 3 + i].re * U[m * 3 + j].im;
+              }
+            }
+          }
+        }
+      }
+
+    /*
+     * Set global 3x3 neutrino mass difference matrix
+     */
+    /// \brief set mass differences to constant memory
+    template<typename FLOAT_T>
+      void setMassDifferences(FLOAT_T* dm){
+        memcpy((FLOAT_T*)mass_data, dm, sizeof(FLOAT_T) * 9);
+#ifdef __NVCC__
+        cudaMemcpyToSymbol(mass_data_device, dm, sizeof(FLOAT_T) * 9 , 0, cudaMemcpyHostToDevice); CUERR;
+#endif
+      }
+
+    /*
+     * Set global 3x3 neutrino mass difference matrix on host only
+     */
+    template<typename FLOAT_T>
+      void setMassDifferences_host(FLOAT_T* dm){
+        memcpy((FLOAT_T*)mass_data, dm, sizeof(FLOAT_T) * 9);
+      }
+
+
+    //
+    template<typename FLOAT_T>
+      void prepare_getMfast(NeutrinoType type) {
+        FLOAT_T alphaV, betaV, gammaV, argV, tmpV;
+        FLOAT_T theta0V, theta1V, theta2V;
+        FLOAT_T mMatV[3];
+
+        /* The strategy to sort out the three roots is to compute the vacuum
+         * mass the same way as the "matter" masses are computed then to sort
+         * the results according to the input vacuum masses
+         */
+        alphaV = DM(0,1) + DM(0,2);
+        betaV = DM(0,1) * DM(0,2);
+        gammaV = 0.0;
+
+        /* Compute the argument of the arc-cosine */
+        tmpV = alphaV*alphaV-3.0*betaV;
+
+        /* Equation (21) */
+        argV = (2.0*alphaV*alphaV*alphaV-9.0*alphaV*betaV+27.0*gammaV)/
+          (2.0*sqrt(tmpV*tmpV*tmpV));
+        if (fabs(argV)>1.0) argV = argV/fabs(argV);
+
+        /* These are the three roots the paper refers to */
+        theta0V = acos(argV)/3.0;
+        theta1V = theta0V-(2.0*M_PI/3.0);
+        theta2V = theta0V+(2.0*M_PI/3.0);
+
+        mMatV[0] = mMatV[1] = mMatV[2] = -(2.0/3.0)*sqrt(tmpV);
+        mMatV[0] *= cos(theta0V); mMatV[1] *= cos(theta1V); mMatV[2] *= cos(theta2V);
+        tmpV = DM(0,0) - alphaV/3.0;
+        mMatV[0] += tmpV; mMatV[1] += tmpV; mMatV[2] += tmpV;
+
+        /* Sort according to which reproduce the vaccum eigenstates */
+        int order[3];
+
+        for (int i=0; i<3; i++) {
+          tmpV = fabs(DM(i,0)-mMatV[0]);
+          int k = 0;
+
+          for (int j=1; j<3; j++) {
+            FLOAT_T tmp = fabs(DM(i,0)-mMatV[j]);
+            if (tmp<tmpV) {
+              k = j;
+              tmpV = tmp;
+            }
+          }
+          order[i] = k;
+        }
+        memcpy(mass_order, order, sizeof(int) * 3);
+
+#ifdef __NVCC__
+        cudaMemcpyToSymbol(mass_order_device, order, sizeof(int) * 3, 0, cudaMemcpyHostToDevice); CUERR;
+#endif
+      }
+
+    /*
+     * Return induced neutrino mass difference matrix d_dmMatMat,
+     * and d_dmMatVac, which is the mass difference matrix between induced masses and vacuum masses
+     *
+     * The strategy to sort out the three roots is to compute the vacuum
+     * mass the same way as the "matter" masses are computed then to sort
+     * the results according to the input vacuum masses. Subsequently, the "matter" masses
+     * are calculated, using the found sorting for vacuum masses
+     *
+     * In the original implementation the order of vacuum masses is computed for each bin.
+     * However, the ordering of vacuum masses does only depend on the constant neutrino mixing matrix.
+     * Thus, the ordering can be precomputed, which is done in prepare_getMfast
+     */
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      void getMfast(const FLOAT_T Enu, const FLOAT_T rho,
+          const NeutrinoType type,
+          FLOAT_T d_dmMatMat[][3], FLOAT_T d_dmMatVac[][3]) {
+
+        FLOAT_T mMatU[3], mMat[3];
+
+        /* Equations (22) fro Barger et.al.*/
+        const FLOAT_T fac = [&](){
+          if(type == Antineutrino)
+            return Constants<FLOAT_T>::tworttwoGf()*Enu*rho;
+          else
+            return -Constants<FLOAT_T>::tworttwoGf()*Enu*rho;
+        }();
+
+        const FLOAT_T alpha  = fac + DM(0,1) + DM(0,2);
+
+        const FLOAT_T beta = DM(0,1)*DM(0,2) +
+          fac*(DM(0,1)*(1.0 -
+                U(0,1).re*U(0,1).re -
+                U(0,1).im*U(0,1).im ) +
+              DM(0,2)*(1.0-
+                U(0,2).re*U(0,2).re -
+                U(0,2).im*U(0,2).im));
+
+
+        const FLOAT_T gamma = fac*DM(0,1)*DM(0,2)*(U(0,0).re * U(0,0).re + U(0,0).im * U(0,0).im);
+
+        /* Compute the argument of the arc-cosine */
+        const FLOAT_T tmp = alpha*alpha-3.0*beta < 0 ? 0 : alpha*alpha-3.0*beta;
+
+        /* Equation (21) */
+        const FLOAT_T argtmp = (2.0*alpha*alpha*alpha-9.0*alpha*beta+27.0*gamma)/
+          (2.0*sqrt(tmp*tmp*tmp));
+        const FLOAT_T arg = [&](){
+          if (fabs(argtmp)>1.0)
+            return argtmp/fabs(argtmp);
+          else
+            return argtmp;
+        }();
+
+        /* These are the three roots the paper refers to */
+        const FLOAT_T theta0 = acos(arg)/3.0;
+        const FLOAT_T theta1 = theta0-(2.0*M_PI/3.0);
+        const FLOAT_T theta2 = theta0+(2.0*M_PI/3.0);
+
+        mMatU[0] = -(2.0/3.0)*sqrt(tmp);
+        mMatU[1] = -(2.0/3.0)*sqrt(tmp);
+        mMatU[2] = -(2.0/3.0)*sqrt(tmp);
+        mMatU[0] *= cos(theta0);
+        mMatU[1] *= cos(theta1);
+        mMatU[2] *= cos(theta2);
+        const FLOAT_T tmp2 = DM(0,0) - alpha/3.0;
+        mMatU[0] += tmp2;
+        mMatU[1] += tmp2;
+        mMatU[2] += tmp2;
+
+        /* Sort according to which reproduce the vaccum eigenstates */
+
+        UNROLLQUALIFIER
+          for (int i=0; i<3; i++) {
+            mMat[i] = mMatU[ORDER(i)];
           }
 
-	  template<typename FLOAT_T>
-            HOSTDEVICEQUALIFIER
-	    void getA(const FLOAT_T L, const FLOAT_T E, const FLOAT_T rho, const FLOAT_T d_dmMatVac[][3], const FLOAT_T d_dmMatMat[][3],
-		      const NeutrinoType type,  const FLOAT_T phase_offset, math::ComplexNumber<FLOAT_T> A[3][3]){
-	      
-	      math::ComplexNumber<FLOAT_T> X[3][3];
-	      math::ComplexNumber<FLOAT_T> product[3][3][3];
-	      /* (1/2)*(1/(h_bar*c)) in units of GeV/(eV^2-km) */
-	      const FLOAT_T LoEfac = 2.534;
-	      
-	      if (phase_offset == 0.0) {
-		get_product(L, E, rho, d_dmMatVac, d_dmMatMat, type, product);
-	      }
-	      
-	      
-	      /* Make the sum with the exponential factor in Eq. (11) */
-	      //memset(X, 0, 3*3*sizeof(math::ComplexNumber<FLOAT_T>));
-	      UNROLLQUALIFIER
-		for (int i=0; i<3; i++) {
-		  UNROLLQUALIFIER
-		    for (int j=0; j<3; j++) {
-		      X[i][j].re = 0;
-		      X[i][j].im = 0;
-		    }
-		}
-	      
-	      UNROLLQUALIFIER
-		for (int k=0; k<3; k++) {
-		  const FLOAT_T arg = [&](){
-		    if( k == 2)
-		      return -LoEfac * d_dmMatVac[k][0] * L/E + phase_offset;
-		    else
-		      return -LoEfac * d_dmMatVac[k][0] * L/E;
-		  }();
-		  
+        UNROLLQUALIFIER
+          for (int i=0; i<3; i++) {
+            UNROLLQUALIFIER
+              for (int j=0; j<3; j++) {
+                d_dmMatMat[i][j] = mMat[i] - mMat[j];
+                d_dmMatVac[i][j] = mMat[i] - DM(j,0);
+              }
+          }
+      }
+
+    /*
+       Calculate the product of Eq. (11)
+       */
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      void get_product(const FLOAT_T L, const FLOAT_T E, const FLOAT_T rho, const FLOAT_T d_dmMatVac[][3], const FLOAT_T d_dmMatMat[][3],
+          const NeutrinoType type, math::ComplexNumber<FLOAT_T> product[][3][3]){
+
+        math::ComplexNumber<FLOAT_T> twoEHmM[3][3][3];
+
+        const FLOAT_T fac = [&](){
+          if(type == Antineutrino)
+            return Constants<FLOAT_T>::tworttwoGf()*E*rho;
+          else
+            return -Constants<FLOAT_T>::tworttwoGf()*E*rho;
+        }();
+
+        /* Calculate the matrix 2EH-M_j */
+        UNROLLQUALIFIER
+          for (int n=0; n<3; n++) {
+            UNROLLQUALIFIER
+              for (int m=0; m<3; m++) {
+                twoEHmM[n][m][0].re = -fac*(U(0,n).re*U(0,m).re+U(0,n).im*U(0,m).im);
+                twoEHmM[n][m][0].im = -fac*(U(0,n).re*U(0,m).im-U(0,n).im*U(0,m).re);
+                twoEHmM[n][m][1].re = -fac*(U(0,n).re*U(0,m).re+U(0,n).im*U(0,m).im);
+                twoEHmM[n][m][1].im = -fac*(U(0,n).re*U(0,m).im-U(0,n).im*U(0,m).re);
+                twoEHmM[n][m][2].re = -fac*(U(0,n).re*U(0,m).re+U(0,n).im*U(0,m).im);
+                twoEHmM[n][m][2].im = -fac*(U(0,n).re*U(0,m).im-U(0,n).im*U(0,m).re);
+              }
+          }
+
+        UNROLLQUALIFIER
+          for (int j=0; j<3; j++){
+            twoEHmM[0][0][j].re-= d_dmMatVac[j][0];
+            twoEHmM[1][1][j].re-= d_dmMatVac[j][1];
+            twoEHmM[2][2][j].re-= d_dmMatVac[j][2];
+          }
+
+        /* Calculate the product in eq.(11) of twoEHmM for j!=k */
+        //memset(product, 0, 3*3*3*sizeof(math::ComplexNumber<FLOAT_T>));
+        UNROLLQUALIFIER
+          for (int i=0; i<3; i++) {
+            UNROLLQUALIFIER
+              for (int j=0; j<3; j++) {
+                UNROLLQUALIFIER
+                  for (int k=0; k<3; k++) {
+                    product[i][j][k].re = 0;
+                    product[i][j][k].im = 0;
+                  }
+              }
+          }
+
+        UNROLLQUALIFIER
+          for (int i=0; i<3; i++) {
+            UNROLLQUALIFIER
+              for (int j=0; j<3; j++) {
+                UNROLLQUALIFIER
+                  for (int k=0; k<3; k++) {
+                    product[i][j][0].re +=
+                      twoEHmM[i][k][1].re*twoEHmM[k][j][2].re -
+                      twoEHmM[i][k][1].im*twoEHmM[k][j][2].im;
+                    product[i][j][0].im +=
+                      twoEHmM[i][k][1].re*twoEHmM[k][j][2].im +
+                      twoEHmM[i][k][1].im*twoEHmM[k][j][2].re;
+
+                    product[i][j][1].re +=
+                      twoEHmM[i][k][2].re*twoEHmM[k][j][0].re -
+                      twoEHmM[i][k][2].im*twoEHmM[k][j][0].im;
+                    product[i][j][1].im +=
+                      twoEHmM[i][k][2].re*twoEHmM[k][j][0].im +
+                      twoEHmM[i][k][2].im*twoEHmM[k][j][0].re;
+
+                    product[i][j][2].re +=
+                      twoEHmM[i][k][0].re*twoEHmM[k][j][1].re -
+                      twoEHmM[i][k][0].im*twoEHmM[k][j][1].im;
+                    product[i][j][2].im +=
+                      twoEHmM[i][k][0].re*twoEHmM[k][j][1].im +
+                      twoEHmM[i][k][0].im*twoEHmM[k][j][1].re;
+                  }
+
+                product[i][j][0].re /= (d_dmMatMat[0][1]*d_dmMatMat[0][2]);
+                product[i][j][0].im /= (d_dmMatMat[0][1]*d_dmMatMat[0][2]);
+                product[i][j][1].re /= (d_dmMatMat[1][2]*d_dmMatMat[1][0]);
+                product[i][j][1].im /= (d_dmMatMat[1][2]*d_dmMatMat[1][0]);
+                product[i][j][2].re /= (d_dmMatMat[2][0]*d_dmMatMat[2][1]);
+                product[i][j][2].im /= (d_dmMatMat[2][0]*d_dmMatMat[2][1]);
+              }
+          }
+      }
+
+    /***********************************************************************
+      getArg
+
+      Transition matrix expanded as A = sum_k C_k exp(i arg_k).
+      This function returns arg, whereas getC returns C.
+      arg has index [k], where k is this expansion index.
+     ***********************************************************************/
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      void getArg(const FLOAT_T L, const FLOAT_T E, const FLOAT_T dmMatVac[][3], const FLOAT_T phase_offset, FLOAT_T arg[3]) {
+
+        /* (1/2)*(1/(h_bar*c)) in units of GeV/(eV^2-km) */
+        const FLOAT_T LoEfac = 2.534;
+
+        for (int k=0; k<3; k++) {
+          arg[k] = -LoEfac*dmMatVac[k][0]*L/E;
+          if ( k==2 ) arg[k] += phase_offset ;
+        }
+      }
+
+    /***********************************************************************
+      getC
+
+      Transition matrix expanded as A = sum_k C_k exp(i arg_k).
+      This function returns C, whereas getArg returns arg.
+      C_{re,im} have indices [k][row][col] where k is this expansion index.
+     ***********************************************************************/
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      void getC(FLOAT_T E, FLOAT_T rho, FLOAT_T dmMatVac[][3], FLOAT_T dmMatMat[][3],
+          cudaprob3::NeutrinoType type, FLOAT_T phase_offset, math::ComplexNumber<FLOAT_T> C[3][3][3]) {
+
+        const int nExp = 3;
+        const int nNuFlav = 3;
+
+        math::ComplexNumber<FLOAT_T> product[nNuFlav][nNuFlav][nExp];
+
+        if (phase_offset == 0.0) {
+          FLOAT_T L = NAN;
+          get_product(L, E, rho, dmMatVac, dmMatMat, type, product);
+        }
+
+        /* Compute the product with the mixing matrices */
+        for (int iExp=0;iExp<nNuFlav;iExp++) {
+          for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
+
+            FLOAT_T RR_nk[nNuFlav] = { 0., 0., 0. };
+            FLOAT_T RI_nk[nNuFlav] = { 0., 0., 0. };
+            FLOAT_T IR_nk[nNuFlav] = { 0., 0., 0. };
+            FLOAT_T II_nk[nNuFlav] = { 0., 0., 0. };
+
+            for (int i=0; i<nNuFlav; i++) {
+              for (int j=0; j<nNuFlav; j++) {
+                RR_nk[j] += U(iNuFlav,i).re * product[i][j][iExp].re;
+                RI_nk[j] += U(iNuFlav,i).re * product[i][j][iExp].im;
+                IR_nk[j] += U(iNuFlav,i).im * product[i][j][iExp].re;
+                II_nk[j] += U(iNuFlav,i).im * product[i][j][iExp].im;
+              }
+            }
+
+            for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) {
+              FLOAT_T ReSum=0., ImSum=0.;
+
+              for (int j=0; j<nNuFlav; j++) {
+                ReSum += RR_nk[j] * U(jNuFlav,j).re;
+                ReSum += RI_nk[j] * U(jNuFlav,j).im;
+                ReSum += IR_nk[j] * U(jNuFlav,j).im;
+                ReSum -= II_nk[j] * U(jNuFlav,j).re;
+
+                ImSum += II_nk[j] * U(jNuFlav,j).im;
+                ImSum += IR_nk[j] * U(jNuFlav,j).re;
+                ImSum += RI_nk[j] * U(jNuFlav,j).re;
+                ImSum -= RR_nk[j] * U(jNuFlav,j).im;
+              }
+
+              C[iExp][iNuFlav][jNuFlav].re = ReSum;
+              C[iExp][iNuFlav][jNuFlav].im = ImSum;
+
+            }
+          }
+        }
+
+      }
+
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      void getA(const FLOAT_T L, const FLOAT_T E, const FLOAT_T rho, const FLOAT_T d_dmMatVac[][3], const FLOAT_T d_dmMatMat[][3],
+          const NeutrinoType type,  const FLOAT_T phase_offset, math::ComplexNumber<FLOAT_T> A[3][3]){
+
+        math::ComplexNumber<FLOAT_T> X[3][3];
+        math::ComplexNumber<FLOAT_T> product[3][3][3];
+        /* (1/2)*(1/(h_bar*c)) in units of GeV/(eV^2-km) */
+        const FLOAT_T LoEfac = 2.534;
+
+        if (phase_offset == 0.0) {
+          get_product(L, E, rho, d_dmMatVac, d_dmMatMat, type, product);
+        }
+
+
+        /* Make the sum with the exponential factor in Eq. (11) */
+        //memset(X, 0, 3*3*sizeof(math::ComplexNumber<FLOAT_T>));
+        UNROLLQUALIFIER
+          for (int i=0; i<3; i++) {
+            UNROLLQUALIFIER
+              for (int j=0; j<3; j++) {
+                X[i][j].re = 0;
+                X[i][j].im = 0;
+              }
+          }
+
+        UNROLLQUALIFIER
+          for (int k=0; k<3; k++) {
+            const FLOAT_T arg = [&](){
+              if( k == 2)
+                return -LoEfac * d_dmMatVac[k][0] * L/E + phase_offset;
+              else
+                return -LoEfac * d_dmMatVac[k][0] * L/E;
+            }();
+
 #ifdef __CUDACC__
-		  FLOAT_T c,s;
-		  sincos(arg, &s, &c);
+            FLOAT_T c,s;
+            sincos(arg, &s, &c);
 #else
-		  const FLOAT_T s = sin(arg);
-		  const FLOAT_T c = cos(arg);
+            const FLOAT_T s = sin(arg);
+            const FLOAT_T c = cos(arg);
 #endif
-		  UNROLLQUALIFIER
-		    for (int i=0; i<3; i++) {
-		      UNROLLQUALIFIER
-			for (int j=0; j<3; j++) {
-			  X[i][j].re += c*product[i][j][k].re - s*product[i][j][k].im;
-			  X[i][j].im += c*product[i][j][k].im + s*product[i][j][k].re;
-			}
-		    }
-		}	      
-	      
-	      /* Eq. (10)*/
-	      //memset(A, 0, 3*3*2*sizeof(FLOAT_T));
-	      
-	      UNROLLQUALIFIER
-		for (int n=0; n<3; n++) {
-		  UNROLLQUALIFIER
-		    for (int m=0; m<3; m++) {
-		      A[n][m].re = 0;
-		      A[n][m].im = 0;
-		    }
-		}	      
-	      UNROLLQUALIFIER
-		for (int n=0; n<3; n++) {
-		  UNROLLQUALIFIER
-		    for (int m=0; m<3; m++) {
-		      UNROLLQUALIFIER
-			for (int i=0; i<3; i++) {
-			  UNROLLQUALIFIER
-			    for (int j=0; j<3; j++) {
-			      // use precomputed factors
-			      A[n][m].re +=
-				AXFAC(n,m,i,j,0) * X[i][j].re +
-				AXFAC(n,m,i,j,1) * X[i][j].im;
-			      A[n][m].im +=
-				AXFAC(n,m,i,j,2) * X[i][j].im +
-				AXFAC(n,m,i,j,3) * X[i][j].re;
-			    }
-			}
-		    }
-		}
-	    }
-	 
-	  /*
-	   * Get 3x3 transition amplitude Aout for neutrino with energy E travelling Len kilometers through matter of constant density rho
-	   */
-	  template<typename FLOAT_T>
-	  HOSTDEVICEQUALIFIER
-	  void get_transition_matrix(NeutrinoType nutype, FLOAT_T Enu, FLOAT_T rho, FLOAT_T Len, math::ComplexNumber<FLOAT_T> Aout[3][3], FLOAT_T phase_offset){
-	    
-	    FLOAT_T d_dmMatVac[3][3], d_dmMatMat[3][3];
-	    getMfast(Enu, rho, nutype, d_dmMatMat, d_dmMatVac);
-	    
-	    getA(Len, Enu, rho, d_dmMatVac, d_dmMatMat, nutype, phase_offset, Aout);
-	  }
+            UNROLLQUALIFIER
+              for (int i=0; i<3; i++) {
+                UNROLLQUALIFIER
+                  for (int j=0; j<3; j++) {
+                    X[i][j].re += c*product[i][j][k].re - s*product[i][j][k].im;
+                    X[i][j].im += c*product[i][j][k].im + s*product[i][j][k].re;
+                  }
+              }
+          }	      
 
-	  //##########################################################
-	  /*
-	   *   Obtain transition matrix expanded as A = sum_k C_k exp(i arg_k).
-	   *   Cout_{re,im} have indices [row][col][k] where k is this expansion index.
-	   *   Cout only depends on nutypei, Enuf and rhof, but not on Lenf.
-	   *   Similarly argout has index [k].
-	   */
-	  template<typename FLOAT_T>
-	  HOSTDEVICEQUALIFIER
-	  void get_transition_matrix_expansion(NeutrinoType nutype, FLOAT_T Enu, FLOAT_T rho, FLOAT_T Len, math::ComplexNumber<FLOAT_T> Cout[3][3][3], FLOAT_T Arg[3], FLOAT_T phase_offset)
-	  {
-	    FLOAT_T d_dmMatVac[3][3], d_dmMatMat[3][3];
-	    getMfast(Enu, rho, nutype, d_dmMatMat, d_dmMatVac);
-	    
-	    getArg(Len, Enu, d_dmMatVac, phase_offset, Arg);
-	    getC(Enu, rho, d_dmMatVac, d_dmMatMat, nutype, phase_offset, Cout);
-	  }
+        /* Eq. (10)*/
+        //memset(A, 0, 3*3*2*sizeof(FLOAT_T));
 
-            /*
-                Find density in layer
-            */
-            template<typename FLOAT_T>
-            HOSTDEVICEQUALIFIER
-            FLOAT_T getDensityOfLayer(const FLOAT_T* const rhos, const FLOAT_T* const yps, int layer, int max_layer){
-                if(layer == 0) return 0.0;
-                int i;
-                if(layer <= max_layer){
-                    i = layer-1;
-                }else{
-                    i = 2 * max_layer - layer - 1;
-                }
+        UNROLLQUALIFIER
+          for (int n=0; n<3; n++) {
+            UNROLLQUALIFIER
+              for (int m=0; m<3; m++) {
+                A[n][m].re = 0;
+                A[n][m].im = 0;
+              }
+          }	      
+        UNROLLQUALIFIER
+          for (int n=0; n<3; n++) {
+            UNROLLQUALIFIER
+              for (int m=0; m<3; m++) {
+                UNROLLQUALIFIER
+                  for (int i=0; i<3; i++) {
+                    UNROLLQUALIFIER
+                      for (int j=0; j<3; j++) {
+                        // use precomputed factors
+                        A[n][m].re +=
+                          AXFAC(n,m,i,j,0) * X[i][j].re +
+                          AXFAC(n,m,i,j,1) * X[i][j].im;
+                        A[n][m].im +=
+                          AXFAC(n,m,i,j,2) * X[i][j].im +
+                          AXFAC(n,m,i,j,3) * X[i][j].re;
+                      }
+                  }
+              }
+          }
+      }
 
-		//printf("yps[%i]:%4.4f",i,yps[i]);
-                return rhos[i]*yps[i];
-            }
+    /*
+     * Get 3x3 transition amplitude Aout for neutrino with energy E travelling Len kilometers through matter of constant density rho
+     */
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      void get_transition_matrix(NeutrinoType nutype, FLOAT_T Enu, FLOAT_T rho, FLOAT_T Len, math::ComplexNumber<FLOAT_T> Aout[3][3], FLOAT_T phase_offset){
 
-            /*
-                Find distance in layer
-            */
-            template<typename FLOAT_T>
-            HOSTDEVICEQUALIFIER
-            FLOAT_T getTraversedDistanceOfLayer(const FLOAT_T* const radii,
-                                                int layer,
-                                                int max_layer,
-                                                FLOAT_T PathLength,
-                                                FLOAT_T TotalEarthLength,
-                                                FLOAT_T cosine_zenith){
+        FLOAT_T d_dmMatVac[3][3], d_dmMatMat[3][3];
+        getMfast(Enu, rho, nutype, d_dmMatMat, d_dmMatVac);
 
-                if(cosine_zenith >= 0) return PathLength;
-                if(layer == 0) return PathLength - TotalEarthLength;
+        getA(Len, Enu, rho, d_dmMatVac, d_dmMatMat, nutype, phase_offset, Aout);
+      }
 
-                int i;
-                if(layer >= max_layer)
-                    i = -layer - 1 + 2 * max_layer;
-                else{
-                    i = layer-1;
-                }
+    //##########################################################
+    /*
+     *   Obtain transition matrix expanded as A = sum_k C_k exp(i arg_k).
+     *   Cout_{re,im} have indices [row][col][k] where k is this expansion index.
+     *   Cout only depends on nutypei, Enuf and rhof, but not on Lenf.
+     *   Similarly argout has index [k].
+     */
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      void get_transition_matrix_expansion(NeutrinoType nutype, FLOAT_T Enu, FLOAT_T rho, FLOAT_T Len, math::ComplexNumber<FLOAT_T> Cout[3][3][3], FLOAT_T Arg[3], FLOAT_T phase_offset)
+      {
+        FLOAT_T d_dmMatVac[3][3], d_dmMatMat[3][3];
+        getMfast(Enu, rho, nutype, d_dmMatMat, d_dmMatVac);
 
-                const FLOAT_T CrossThis = 2.0*sqrt( radii[i] * radii[i]  - (Constants<FLOAT_T>::REarth())*(Constants<FLOAT_T>::REarth())*( 1 - cosine_zenith*cosine_zenith ) );
-                const FLOAT_T CrossNext = 2.0*sqrt( radii[i+1] * radii[i+1] - (Constants<FLOAT_T>::REarth())*((FLOAT_T)Constants<FLOAT_T>::REarth())*( 1 -cosine_zenith*cosine_zenith ) );
+        getArg(Len, Enu, d_dmMatVac, phase_offset, Arg);
+        getC(Enu, rho, d_dmMatVac, d_dmMatMat, nutype, phase_offset, Cout);
+      }
 
-                if(i < max_layer - 1){
-                    return 0.5*( CrossThis-CrossNext )*(Constants<FLOAT_T>::km2cm());
-                }else{
-                    return CrossThis*(Constants<FLOAT_T>::km2cm());
-                }
-            }
+    /*
+       Find density in layer
+       */
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      FLOAT_T getDensityOfLayer(const FLOAT_T* const rhos, const FLOAT_T* const yps, int layer, int max_layer){
+        if(layer == 0) return 0.0;
+        int i;
+        if(layer <= max_layer){
+          i = layer-1;
+        }else{
+          i = 2 * max_layer - layer - 1;
+        }
 
-	  template<typename FLOAT_T>
-	  HOSTDEVICEQUALIFIER
-	  void calculate(NeutrinoType type,
-			 const FLOAT_T* const cosinelist,
-			 int n_cosines,
-			 const FLOAT_T* const energylist,
-			 int n_energies,
-			 const FLOAT_T* const radii,
-			 const FLOAT_T* const rhos,
-			 const FLOAT_T* const yps,
-			 const int* const maxlayers,
-			 FLOAT_T ProductionHeightinCentimeter,
-			 bool useProductionHeightAveraging,
-			 int nProductionHeightBins,
-			 const FLOAT_T* const productionHeight_prob_list, // 20 (nBins) * 2 (nu,nubar) * 3 (e,mu,tau) * n_energies * n_cosines
-			 const FLOAT_T* const productionHeight_binedges_list, // 21 (BinEdges) in cm
-			 FLOAT_T* const result){
-	    
-            //prepare more constant data. For the kernel, this is done by the wrapper function callCalculateKernelAsync
+        return rhos[i]*yps[i];
+      }
+
+    /*
+       Find density in layer using the cubic polynomials
+       */
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      FLOAT_T getDensityOfLayerPoly(
+          const FLOAT_T* const A_COEFF, // Polynomial coefficients
+          const FLOAT_T* const B_COEFF, // All assuming meter
+          const FLOAT_T* const C_COEFF,
+          const FLOAT_T costheta, // Need to pass costheta
+          const FLOAT_T* const radius, // in km
+          const FLOAT_T* const yps, // electron density
+          const int layer, 
+          const int max_layer,
+          const FLOAT_T distance) // in cm
+      {
+        // Replicated in getTraversedDistanceOfLayer
+        // If we never actually hit earth
+        // Special case again
+        if (costheta >= 0) return 0;
+        // If we're in the vacuum layer, there is no density
+        if (layer == 0) return 0;
+
+        // As i increases, we're getting closer to the earth core
+        int i;
+        if (layer <= max_layer) {
+          i = layer-1;
+        } else {
+          i = 2 * max_layer - layer - 1;
+        }
+
+        // We now have our layer
+        // For constant density we could just do this:
+        // return rhos[i]*yps[i];
+        // But now we have an exciting variable density
+
+        // Calculate the nearest approach to the center (km^2)
+        const FLOAT_T Rmin2 = pow(Constants<FLOAT_T>::REarth(), 2)*(1-pow(costheta, 2));
+        // And the max radius is simply the radius of this shell (km^2)
+        const FLOAT_T Rmax2 = pow(radius[i], 2);
+        // distance in km
+        const FLOAT_T dist = sqrt(Rmax2 - Rmin2);
+
+        // If Rmin2 is zero we're coming right along the radius, so don't need any of the below transforms
+        if (Rmin2 == 0) {
+          // Use the usual rho(R) = a R^2 + b R + c, and integrate it
+          FLOAT_T posterm = A_COEFF[i]*pow(radius[i], 3)/3. + B_COEFF[i]*pow(radius[i], 2)/2. + C_COEFF[i]*radius[i];
+          FLOAT_T negterm = A_COEFF[i]*pow(radius[i+1], 3)/3. + B_COEFF[i]*pow(radius[i+1], 2)/2. + C_COEFF[i]*radius[i+1];
+          FLOAT_T density = posterm - negterm;
+          // For the average
+          density /= (radius[i]-radius[i+1]);
+          return density*yps[i];
+        }
+
+        // These are the solutions to parametrising R = a*t^2 + b*t + c, where a, b, c are just convenience variables with exact solutions:
+        const FLOAT_T a = 1.0;
+        const FLOAT_T b = -2*dist;
+        const FLOAT_T c = Rmax2;
+
+        // in cm, convert to km
+        //FLOAT_T t2 = distance/Constants<FLOAT_T>::km2cm();
+        FLOAT_T t2 = distance*1.e-5;
+        // Really only keeping this here so it's easier to follow derivation
+        const FLOAT_T t1 = 0.;
+
+        // Now write the solutions for the integrals of density over the path
+        // Parameterise density as density = a*r^2 + b*r + c
+        //
+        // Start with the r^2 term:
+        FLOAT_T square_term_p = a*pow(t2,3)/3. + b*pow(t2,2)/2. + c*t2;
+        FLOAT_T square_term_m = a*pow(t1,3)/3. + b*pow(t1,2)/2. + c*t1;
+        // Their difference (integral between t2 and t1)
+        FLOAT_T square_term = square_term_p-square_term_m;
+
+        // Do the r term:
+        // The upper end, first term
+        FLOAT_T lin_term_p1 = (b+2.*a*t2)*sqrt(c+t2*(b+a*t2))/(4.*a);
+        // The lower end, first term
+        FLOAT_T lin_term_m1 = (b+2.*a*t1)*sqrt(c+t1*(b+a*t1))/(4.*a);
+
+        // The second terms
+        FLOAT_T lin_term_p2 = (b*b-4.*a*c)*log(b+2.*a*t2+2.*sqrt(a)*sqrt(c+t2*(b+a*t2)))/(8.*pow(a,3./2.));
+        FLOAT_T lin_term_m2 = (b*b-4.*a*c)*log(b+2.*a*t1+2.*sqrt(a)*sqrt(c+t1*(b+a*t1)))/(8.*pow(a,3./2.));
+        FLOAT_T lin_term = (lin_term_p1-lin_term_p2)-(lin_term_m1-lin_term_m2);
+
+        // And the constant term
+        FLOAT_T con_term = t2-t1;
+
+        // Finally combine as integral = integral(A*r2 + b*r + c)
+        FLOAT_T density = (A_COEFF[i]*square_term + B_COEFF[i]*lin_term + C_COEFF[i]*con_term)/(t2-t1);
+
+        return density*yps[i];
+      }
+
+    /*
+       Find distance in layer
+       Return in cm
+       */
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      FLOAT_T getTraversedDistanceOfLayer(
+          const FLOAT_T* const radii, // in km
+          int layer,
+          int max_layer,
+          FLOAT_T PathLength, // cm
+          FLOAT_T TotalEarthLength, // cm
+          FLOAT_T cosine_zenith){
+
+        // If we never actually hit earth (cos zenith = 0 just skims the surface)
+        // We then just return the path length; i.e. the distance between the production point and the detector
+        if (cosine_zenith >= 0) return PathLength;
+        // If we are in the air layer, we don't traverse any earth, so just return the total path length subtracted by the distance traversed in earth
+        if (layer == 0) return PathLength - TotalEarthLength;
+
+        // As i increases, we're getting closer to the earth core
+        int i;
+        if (layer <= max_layer) {
+          i = layer-1;
+        } else {
+          i = 2 * max_layer - layer -1;
+        }
+
+        // Impact parameter for this cos zenith (nearest distance from center)
+        // in km this time
+        const FLOAT_T R2min = Constants<FLOAT_T>::REarth()*Constants<FLOAT_T>::REarth()*(1-cosine_zenith*cosine_zenith);
+
+        // in km
+        FLOAT_T CrossThis = 2.0*sqrt(radii[i]*radii[i] - R2min);
+        if (sqrt(R2min) > radii[i]) CrossThis = 0;
+        // in km
+        FLOAT_T CrossNext = 2.0*sqrt(radii[i+1]*radii[i+1] - R2min);
+        if (sqrt(R2min) > radii[i+1]) CrossNext = 0;
+
+        if (i < max_layer - 1) {
+          // Convert to cm
+          return 0.5*( CrossThis-CrossNext )*(Constants<FLOAT_T>::km2cm());
+        } else {
+          // Convert to cm
+          return CrossThis*(Constants<FLOAT_T>::km2cm());
+        }
+      }
+
+    template<typename FLOAT_T>
+      HOSTDEVICEQUALIFIER
+      void calculate(NeutrinoType type,
+          const FLOAT_T* const cosinelist,
+          int n_cosines,
+          const FLOAT_T* const energylist,
+          int n_energies,
+          const FLOAT_T* const radii,
+          const FLOAT_T* const as,
+          const FLOAT_T* const bs,
+          const FLOAT_T* const cs,
+          const FLOAT_T* const rhos,
+          const FLOAT_T* const yps,
+          const int* const maxlayers,
+          FLOAT_T ProductionHeightinCentimeter,
+          bool useProductionHeightAveraging,
+          int nProductionHeightBins,
+          const FLOAT_T* const productionHeight_prob_list, // 20 (nBins) * 2 (nu,nubar) * 3 (e,mu,tau) * n_energies * n_cosines
+          const FLOAT_T* const productionHeight_binedges_list, // 21 (BinEdges) in cm
+          FLOAT_T* const result){
+
+        //prepare more constant data. For the kernel, this is done by the wrapper function callCalculateKernelAsync
 #ifndef __CUDA_ARCH__
-	    prepare_getMfast<FLOAT_T>(type);
+        prepare_getMfast<FLOAT_T>(type);
 #endif
+        // Save some memory and access by defining these here
+        const int iLayerAtm = 0;
+        const int nExp = 3;
+        const int nEig = 3;
+        const int nNuFlav = 3;
 
 #ifdef __CUDA_ARCH__
-	    // on the device, we use the global thread Id to index the data
-	    const int max_energies_per_path = SDIV(n_energies, blockDim.x) * blockDim.x;
-	    for(unsigned index = blockIdx.x * blockDim.x + threadIdx.x; index < n_cosines * max_energies_per_path; index += blockDim.x * gridDim.x){
-	      const unsigned index_energy = index % max_energies_per_path;
-	      const unsigned index_cosine = index / max_energies_per_path;
+        // on the device, we use the global thread Id to index the data
+        const int max_energies_per_path = SDIV(n_energies, blockDim.x) * blockDim.x;
+        for(unsigned index = blockIdx.x * blockDim.x + threadIdx.x; index < n_cosines * max_energies_per_path; index += blockDim.x * gridDim.x){
+          const unsigned index_energy = index % max_energies_per_path;
+          const unsigned index_cosine = index / max_energies_per_path;
 #else
-	      // on the host, we use OpenMP to parallelize looping over cosines
+          // on the host, we use OpenMP to parallelize looping over cosines
 #pragma omp parallel for schedule(dynamic)
-	      for(int index_cosine = 0; index_cosine < n_cosines; index_cosine += 1){
+          for(int index_cosine = 0; index_cosine < n_cosines; index_cosine += 1) {
 #endif
-		
-		const FLOAT_T cosine_zenith = cosinelist[index_cosine];
-		
-		const int iLayerAtm = 0;
-		const FLOAT_T TotalEarthLength =  -2.0*cosine_zenith*Constants<FLOAT_T>::REarthcm(); // in [cm]
-		const int MaxLayer = maxlayers[index_cosine];
 
-		const int nExp = 3;
-		const int nEig = 3;
-		const int nNuFlav = 3;
+            // Which costheta are we concerned with
+            const FLOAT_T cosine_zenith = cosinelist[index_cosine];
 
-		FLOAT_T phaseOffset = 0.;
+            // The length of earth for a trajectory of this cos(theta) in cm
+            const FLOAT_T TotalEarthLength =  -2.0*cosine_zenith*Constants<FLOAT_T>::REarthcm();
+            const int MaxLayer = maxlayers[index_cosine];
 
-		const int nMaxLayers = Constants<FLOAT_T>::MaxNLayers();
+            FLOAT_T phaseOffset = 0.;
 
-		math::ComplexNumber<FLOAT_T> TransitionMatrix[nNuFlav][nNuFlav];
-		math::ComplexNumber<FLOAT_T> TransitionMatrixCoreToMantle[nNuFlav][nNuFlav];
-		math::ComplexNumber<FLOAT_T> finalTransitionMatrix[nNuFlav][nNuFlav];
-		math::ComplexNumber<FLOAT_T> TransitionTemp[nNuFlav][nNuFlav];
+            const int nMaxLayers = Constants<FLOAT_T>::MaxNLayers();
 
-		math::ComplexNumber<FLOAT_T> ExpansionMatrix[nMaxLayers][nExp][nNuFlav][nNuFlav];
-		FLOAT_T arg[nMaxLayers][nNuFlav];
+            math::ComplexNumber<FLOAT_T> TransitionMatrix[nNuFlav][nNuFlav];
+            math::ComplexNumber<FLOAT_T> TransitionMatrixCoreToMantle[nNuFlav][nNuFlav];
+            math::ComplexNumber<FLOAT_T> finalTransitionMatrix[nNuFlav][nNuFlav];
+            math::ComplexNumber<FLOAT_T> TransitionTemp[nNuFlav][nNuFlav];
 
-		/*
-		// DB Uncomment for debugging get_transition_matrix against get_transition_matrix_expansion
-		math::ComplexNumber<FLOAT_T> TransitionMatrix_getA[nNuFlav][nNuFlav];
-		*/
+            math::ComplexNumber<FLOAT_T> ExpansionMatrix[nMaxLayers][nExp][nNuFlav][nNuFlav];
+            FLOAT_T arg[nMaxLayers][nNuFlav];
 
-		FLOAT_T Prob[nNuFlav][nNuFlav];
+            FLOAT_T Prob[nNuFlav][nNuFlav];
 
-		math::ComplexNumber<FLOAT_T> totalLenShiftFactor[nEig][nEig][nExp];
-		FLOAT_T darg0_ddistance[nNuFlav];
+            math::ComplexNumber<FLOAT_T> totalLenShiftFactor[nEig][nEig][nExp];
+            FLOAT_T darg0_ddistance[nNuFlav];
 
-		math::ComplexNumber<FLOAT_T> Product[nExp][nNuFlav][nNuFlav];
+            math::ComplexNumber<FLOAT_T> Product[nExp][nNuFlav][nNuFlav];
 
 #ifndef __CUDA_ARCH__
-		for(int index_energy = 0; index_energy < n_energies; index_energy += 1){
+            for(int index_energy = 0; index_energy < n_energies; index_energy += 1){
 #else
-		  if(index_energy < n_energies){
+              if(index_energy < n_energies){
 #endif
-		    const FLOAT_T energy = energylist[index_energy];
-		    		    
-		    //============================================================================================================
-		    //DB Reset all the values
+                const FLOAT_T energy = energylist[index_energy];
 
-		    UNROLLQUALIFIER
-		      for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-			UNROLLQUALIFIER
-			  for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) {
-			    Prob[iNuFlav][jNuFlav] = 0.;
-			  }
-		      }
-		    
-		    for (int iExp=0;iExp<nExp;iExp++) {
-		      clear_complex_matrix(Product[iExp]);
-		    }
+                //============================================================================================================
+                //DB Reset all the values
 
-		    // set TransitionMatrixCoreToMantle to unit matrix
-		    UNROLLQUALIFIER
-		      for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-			UNROLLQUALIFIER
-			for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) {
-			    TransitionMatrixCoreToMantle[iNuFlav][jNuFlav].re = (iNuFlav == jNuFlav ? 1.0 : 0.0);
-			    TransitionMatrixCoreToMantle[iNuFlav][jNuFlav].im = 0.0;
-			  }
-		      }
+                UNROLLQUALIFIER
+                  for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
+                    UNROLLQUALIFIER
+                      for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) {
+                        Prob[iNuFlav][jNuFlav] = 0.;
+                      }
+                  }
 
-		    //============================================================================================================
-		    //DB Calculate Path Lengths for given production heights
+                for (int iExp=0;iExp<nExp;iExp++) {
+                  clear_complex_matrix(Product[iExp]);
+                }
 
-		    //DB PathLength is used to calculate the distance traversed
-		    const FLOAT_T PathLength = sqrt((Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter )*(Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter)
-						    - (Constants<FLOAT_T>::REarthcm()*Constants<FLOAT_T>::REarthcm())*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith;
+                // set TransitionMatrixCoreToMantle to unit matrix
+                UNROLLQUALIFIER
+                  for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
+                    UNROLLQUALIFIER
+                      for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) {
+                        TransitionMatrixCoreToMantle[iNuFlav][jNuFlav].re = (iNuFlav == jNuFlav ? 1.0 : 0.0);
+                        TransitionMatrixCoreToMantle[iNuFlav][jNuFlav].im = 0.0;
+                      }
+                  }
 
-		    //============================================================================================================
-		    //DB Loop over layers		    
+                //============================================================================================================
+                //DB Calculate Path Lengths for given production heights
 
-		    // loop from vacuum layer to innermost crossed layer
-		    for (int iLayer=0;iLayer<=MaxLayer;iLayer++){
-		      const FLOAT_T distance = getTraversedDistanceOfLayer(radii, iLayer, MaxLayer, PathLength, TotalEarthLength, cosine_zenith);
-		      const FLOAT_T density = getDensityOfLayer(rhos, yps, iLayer, MaxLayer);
-		     
-		      /*
-		      //DB Uncomment for debugging get_transition_matrix against get_transition_matrix_expansion
-		      get_transition_matrix(type,
-					    energy,
-					    density * Constants<FLOAT_T>::density_convert(),
-					    distance / Constants<FLOAT_T>::km2cm(),
-					    TransitionMatrix_getA,
-					    phaseOffset
-					    );
-		      */
+                // DB PathLength is used to calculate the distance traversed
+                // in cm
+                const FLOAT_T PathLength = sqrt((Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter )*(Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter)
+                    - (Constants<FLOAT_T>::REarthcm()*Constants<FLOAT_T>::REarthcm())*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith;
 
-		      /*
-		      for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-			clear_complex_matrix(ExpansionMatrix[iLayer][iNuFlav]);
-		      }
-		      */
+                //============================================================================================================
+                //DB Loop over layers		    
 
-		      get_transition_matrix_expansion(type,
-						      energy,
-						      density /** Constants<FLOAT_T>::density_convert()*/,
-						      distance / Constants<FLOAT_T>::km2cm(),
-						      ExpansionMatrix[iLayer],
-						      arg[iLayer],
-						      phaseOffset
-						      ); 
-		
-		      //DB For each layer, A = sum_k C[k] exp(i a[k])
-		      clear_complex_matrix(TransitionMatrix);
+                // loop from vacuum layer to innermost crossed layer
+                for (int iLayer=0;iLayer<=MaxLayer;iLayer++){
+                  // Distance travelled for this cos zenith
+                  // in cm
+                  const FLOAT_T dist = getTraversedDistanceOfLayer(radii, iLayer, MaxLayer, PathLength, TotalEarthLength, cosine_zenith);
 
-		      for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-			multiply_phase_matrix(arg[iLayer][iNuFlav],ExpansionMatrix[iLayer][iNuFlav],TransitionMatrix);
-		      }
-		      
-		      /*
-		      //DB Uncomment for debugging get_transition_matrix against get_transition_matrix_expansion
-		      for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-			for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) {
-			  
-			  if ( fabs(TransitionMatrix[iNuFlav][jNuFlav].re - TransitionMatrix_getA[iNuFlav][jNuFlav].re)>1e-9 || fabs(TransitionMatrix[iNuFlav][jNuFlav].im - TransitionMatrix_getA[iNuFlav][jNuFlav].im)>1e-9 ) {
-			    printf("TransitionMatrix[iNuFlav][jNuFlav].re: %4.2f \n",TransitionMatrix[iNuFlav][jNuFlav].re);
-			    printf("TransitionMatrix[iNuFlav][jNuFlav].im: %4.2f \n",TransitionMatrix[iNuFlav][jNuFlav].im);
-			    printf("TransitionMatrix_getA[iNuFlav][jNuFlav].re: %4.2f \n",TransitionMatrix_getA[iNuFlav][jNuFlav].re);
-			    printf("TransitionMatrix_getA[iNuFlav][jNuFlav].im: %4.2f \n",TransitionMatrix_getA[iNuFlav][jNuFlav].im);
+                  // Get the density for this path in this layer
+                  //const FLOAT_T density = getDensityOfLayer(rhos, yps, iLayer, MaxLayer);
 
-			    std::cout << "------------ Arg[i] -------------" << std::endl;
-			    for (int kNuFlav=0;kNuFlav<nNuFlav;kNuFlav++) {
-			      std::cout << "arg[" << kNuFlav << "]:" << arg[iLayer][kNuFlav] << std::endl;
-			    }
+                  // There's now a density for every single cos theta
+                  const FLOAT_T density = getDensityOfLayerPoly(as, bs, cs, cosine_zenith, radii, yps, iLayer, MaxLayer, dist);
+                  //std::cout << "cos zenith: " << cosine_zenith << " layer: " << iLayer << " / " << MaxLayer << " distance: " << dist << " density: " << density << std::endl;
+                  //std::cout << "  " << altdensity << std::endl;
 
-			    std::cout << "------------ ExpansionMatrix[iLayer,iExp,kNuFlav,mNuFlav] -------------" << std::endl;
-			    for (int iExp=0;iExp<nExp;iExp++) {
-			      for (int kNuFlav=0;kNuFlav<nNuFlav;kNuFlav++) {
-				for (int mNuFlav=0;mNuFlav<nNuFlav;mNuFlav++) {
-				  std::cout << "ExpansionMatrix[" << iLayer << "," << iExp << "," << kNuFlav << "," << mNuFlav << "].re:" << ExpansionMatrix[iLayer][iExp][kNuFlav][mNuFlav].re << std::endl;
-				  std::cout << "ExpansionMatrix[" << iLayer << "," << iExp << "," << kNuFlav << "," << mNuFlav << "].im:" << ExpansionMatrix[iLayer][iExp][kNuFlav][mNuFlav].im << std::endl;
-				}
-			      }
-			    }
+                  /*
+                  //DB Uncomment for debugging get_transition_matrix against get_transition_matrix_expansion
+                  get_transition_matrix(type,
+                  energy,
+                  density * Constants<FLOAT_T>::density_convert(),
+                  dist / Constants<FLOAT_T>::km2cm(),
+                  TransitionMatrix_getA,
+                  phaseOffset
+                  );
+                  */
 
-			    std::cout << "------------ TransitionMatrix[kNuFlav,mNuFlav] -------------" << std::endl;
-			    for (int kNuFlav=0;kNuFlav<nNuFlav;kNuFlav++) {
-			      for (int mNuFlav=0;mNuFlav<nNuFlav;mNuFlav++) {
+                  /*
+                     for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
+                     clear_complex_matrix(ExpansionMatrix[iLayer][iNuFlav]);
+                     }
+                     */
 
-				if (fabs(TransitionMatrix[kNuFlav][mNuFlav].re) < 1e-9) {
-				  std::cout << "TransitionMatrix[" << kNuFlav << "," << mNuFlav << "].re:" << 0 << std::endl;
-				} else {
-				  std::cout << "TransitionMatrix[" << kNuFlav << "," << mNuFlav << "].re:" << TransitionMatrix[kNuFlav][mNuFlav].re << std::endl;
-				}
+                  get_transition_matrix_expansion(type,
+                      energy,
+                      density /** Constants<FLOAT_T>::density_convert()*/,
+                      dist / Constants<FLOAT_T>::km2cm(), // Convert back to km
+                      ExpansionMatrix[iLayer],
+                      arg[iLayer],
+                      phaseOffset
+                      ); 
 
-				if (fabs(TransitionMatrix[kNuFlav][mNuFlav].im) < 1e-9) {
-				  std::cout << "TransitionMatrix[" << kNuFlav << "," << mNuFlav << "].im:" << 0 << std::endl;
-				} else {
-				  std::cout << "TransitionMatrix[" << kNuFlav << "," << mNuFlav << "].im:" << TransitionMatrix[kNuFlav][mNuFlav].im << std::endl;
-				}
-			      }
-			    }
+                  //DB For each layer, A = sum_k C[k] exp(i a[k])
+                  clear_complex_matrix(TransitionMatrix);
 
-			    std::cout << "------------ TransitionMatrix_getA[kNuFlav,mNuFlav] -------------" << std::endl;
-			    for (int kNuFlav=0;kNuFlav<nNuFlav;kNuFlav++) {
-			      for (int mNuFlav=0;mNuFlav<nNuFlav;mNuFlav++) {
+                  for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
+                    multiply_phase_matrix(arg[iLayer][iNuFlav],ExpansionMatrix[iLayer][iNuFlav],TransitionMatrix);
+                  }
 
-				if (fabs(TransitionMatrix_getA[kNuFlav][mNuFlav].re) < 1e-9) {
-				  std::cout << "TransitionMatrix_getA[" << kNuFlav << "," << mNuFlav << "].re:" << 0 << std::endl;
-				} else {
-				  std::cout << "TransitionMatrix_getA[" << kNuFlav << "," << mNuFlav << "].re:" << TransitionMatrix_getA[kNuFlav][mNuFlav].re << std::endl;
-				}
+                  if (iLayer == iLayerAtm) { // atmosphere
 
-				if (fabs(TransitionMatrix_getA[kNuFlav][mNuFlav].im) < 1e-9) {
-				  std::cout << "TransitionMatrix_getA[" << kNuFlav << "," << mNuFlav << "].im:" << 0 << std::endl;
-				} else {
-				  std::cout << "TransitionMatrix_getA[" << kNuFlav << "," << mNuFlav << "].im:" << TransitionMatrix_getA[kNuFlav][mNuFlav].im << std::endl;
-				}
-			      }
-			    }
+                    copy_complex_matrix(TransitionMatrix , finalTransitionMatrix);
 
-			    std::exit(-1);
-			  }
-			}
-		      }
-		      */
+                    if (dist==0.) {
+                      for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
+                        darg0_ddistance[iNuFlav] = 0.;
+                      }
+                    }
+                    else {
+                      for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
+                        darg0_ddistance[iNuFlav] = arg[iLayerAtm][iNuFlav]/dist;
+                      }
+                    }
 
-		      if (iLayer == iLayerAtm) { // atmosphere
+                  } else if (iLayer < MaxLayer) { // not the innermost layer, can reuse current TransitionMatrix
+                    clear_complex_matrix( TransitionTemp );
+                    multiply_complex_matrix( TransitionMatrix, finalTransitionMatrix, TransitionTemp );
+                    copy_complex_matrix( TransitionTemp, finalTransitionMatrix );
 
-			copy_complex_matrix(TransitionMatrix , finalTransitionMatrix);
-			
-			if (distance==0.) {
-			  for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-			    darg0_ddistance[iNuFlav] = 0.;
-			  }
-			}
-			else {
-			  for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-			    darg0_ddistance[iNuFlav] = arg[iLayerAtm][iNuFlav]/distance;
-			  }
-			}
+                    clear_complex_matrix( TransitionTemp );
+                    multiply_complex_matrix( TransitionMatrixCoreToMantle, TransitionMatrix, TransitionTemp );
+                    copy_complex_matrix( TransitionTemp, TransitionMatrixCoreToMantle );
+                  } else { // innermost layer
+                    clear_complex_matrix( TransitionTemp );
+                    multiply_complex_matrix( TransitionMatrix, finalTransitionMatrix, TransitionTemp );
+                    copy_complex_matrix( TransitionTemp, finalTransitionMatrix );
+                  }
 
-		      } else if (iLayer < MaxLayer) { // not the innermost layer, can reuse current TransitionMatrix
-			clear_complex_matrix( TransitionTemp );
-			multiply_complex_matrix( TransitionMatrix, finalTransitionMatrix, TransitionTemp );
-			copy_complex_matrix( TransitionTemp, finalTransitionMatrix );
-			
-			clear_complex_matrix( TransitionTemp );
-			multiply_complex_matrix( TransitionMatrixCoreToMantle, TransitionMatrix, TransitionTemp );
-			copy_complex_matrix( TransitionTemp, TransitionMatrixCoreToMantle );
-		      } else { // innermost layer
-			clear_complex_matrix( TransitionTemp );
-			multiply_complex_matrix( TransitionMatrix, finalTransitionMatrix, TransitionTemp );
-			copy_complex_matrix( TransitionTemp, finalTransitionMatrix );
-		      }
+                }
 
-		    }
-		    
-		    // calculate final transition matrix
-		    clear_complex_matrix( TransitionTemp );
-		    multiply_complex_matrix( TransitionMatrixCoreToMantle, finalTransitionMatrix, TransitionTemp );
-		    copy_complex_matrix( TransitionTemp, finalTransitionMatrix );
+                // calculate final transition matrix
+                clear_complex_matrix( TransitionTemp );
+                multiply_complex_matrix( TransitionMatrixCoreToMantle, finalTransitionMatrix, TransitionTemp );
+                copy_complex_matrix( TransitionTemp, finalTransitionMatrix );
 
-		    //============================================================================================================
-		    //DB Calculate totalLenShiftFactors using atmospheric layer
-		    
-		    //
-		    //DB Set unit matrix
-		    if (useProductionHeightAveraging) {
-		      UNROLLQUALIFIER
-			for (int iEig0=0;iEig0<nEig;iEig0++) {
-			  UNROLLQUALIFIER
-			    for (int jEig0=0;jEig0<nEig;jEig0++) {
-			      UNROLLQUALIFIER
-				for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-				  totalLenShiftFactor[iEig0][jEig0][iNuFlav].re = (iEig0 == jEig0 ? 1.0 : 0.0);
-				  totalLenShiftFactor[iEig0][jEig0][iNuFlav].im = 0.;
-				}
-			    }
-			}
+                //============================================================================================================
+                //DB Calculate totalLenShiftFactors using atmospheric layer
 
-		      const int nMaxProductionHeightBins = Constants<FLOAT_T>::MaxProdHeightBins();
-		      FLOAT_T PathLengthShifts[nMaxProductionHeightBins+1];
+                //
+                //DB Set unit matrix
+                if (useProductionHeightAveraging) {
+                  UNROLLQUALIFIER
+                    for (int iEig0=0;iEig0<nEig;iEig0++) {
+                      UNROLLQUALIFIER
+                        for (int jEig0=0;jEig0<nEig;jEig0++) {
+                          UNROLLQUALIFIER
+                            for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
+                              totalLenShiftFactor[iEig0][jEig0][iNuFlav].re = (iEig0 == jEig0 ? 1.0 : 0.0);
+                              totalLenShiftFactor[iEig0][jEig0][iNuFlav].im = 0.;
+                            }
+                        }
+                    }
 
-		      UNROLLQUALIFIER
-			for (int iProductionHeight=0;iProductionHeight<(nProductionHeightBins+1);iProductionHeight++) {
-			  FLOAT_T iVal_ProdHeightInCentimeter = Constants<FLOAT_T>::km2cm() * productionHeight_binedges_list[iProductionHeight];
-			  FLOAT_T iVal_PathLength = (sqrt((Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter )*(Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter)
-							  - (Constants<FLOAT_T>::REarthcm()*Constants<FLOAT_T>::REarthcm())*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith);
-			  
-			  PathLengthShifts[iProductionHeight] = iVal_PathLength - PathLength;
-			}
-		      
-		      UNROLLQUALIFIER
-			for (int iPathLength=0;iPathLength<nProductionHeightBins;iPathLength++) {
-			  //PathLengthShifts is of size equal to the number of Production Height bin edges
-			  FLOAT_T h0 = PathLengthShifts[iPathLength];
-			  FLOAT_T h1 = PathLengthShifts[iPathLength+1];
-			  FLOAT_T hm = (h1+h0)/2.;
-			  FLOAT_T hw = (h1-h0);
-			  
-			  UNROLLQUALIFIER
-			    for (int iEig0=0;iEig0<nEig;iEig0++) { 
-			      UNROLLQUALIFIER
-				for (int jEig0=0;jEig0<iEig0;jEig0++) { 
-				  FLOAT_T darg_distance = darg0_ddistance[iEig0]-darg0_ddistance[jEig0];
-				  
-				  //factor.re = 0
-				  //factor.im = darg_distance*hm
-				  //
-				  //exp(factor).re = exp(f.re)*cos(f.im) = cos(darg_distance*hm)
-				  //exp(factor).im = exp(f.re)*sin(f.im) = sin(darg_distance*hm)
-				  //
-				  //sinc(0.5 * darg_distance * hw) * exp(factor).re = sinc(0.5 * darg_distance * hw) * cos(darg_distance * hm)
-				  //sinc(0.5 * darg_distance * hw) * exp(factor).re = sinc(0.5 * darg_distance * hw) * sin(darg_distance * hm)
-				  
-				  math::ComplexNumber<FLOAT_T> sinc_exp_factor; 
-				  FLOAT_T Sinc_Arg = 0.5 * darg_distance * hw;
-				  
-				  sinc_exp_factor.re = cudaprob3::math::defined_sinc(Sinc_Arg) * cos(darg_distance * hm);
-				  sinc_exp_factor.im = cudaprob3::math::defined_sinc(Sinc_Arg) * sin(darg_distance * hm);
-				  
-				  UNROLLQUALIFIER
-				    for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //In flav
-				      
-				      int ProbIndex = type*nNuFlav*n_energies*n_cosines*nProductionHeightBins + iNuFlav*n_energies*n_cosines*nProductionHeightBins
-					+ index_energy*n_cosines*nProductionHeightBins + index_cosine*nProductionHeightBins + iPathLength;
-				      //productionHeight_prob_list is of size equal to the number of production height bins * nNuTypes * nNuFlavouts * n_energies * n_cosines
-				      FLOAT_T ProdHeightProb = productionHeight_prob_list[ProbIndex];
-				      
-				      totalLenShiftFactor[iEig0][jEig0][iNuFlav].re += ProdHeightProb * sinc_exp_factor.re;
-				      totalLenShiftFactor[iEig0][jEig0][iNuFlav].im += ProdHeightProb * sinc_exp_factor.im;
-				      
-				      totalLenShiftFactor[jEig0][iEig0][iNuFlav].re += ProdHeightProb * sinc_exp_factor.re;
-				      totalLenShiftFactor[jEig0][iEig0][iNuFlav].im -= ProdHeightProb * sinc_exp_factor.im;
-				    }
-				}
-			    }
-			}
-		    } else {
-		      UNROLLQUALIFIER
-			for (int iEig0=0;iEig0<nEig;iEig0++) {
-			  UNROLLQUALIFIER
-			    for (int jEig0=0;jEig0<iEig0;jEig0++) {
-			      UNROLLQUALIFIER
-				for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
-				  totalLenShiftFactor[iEig0][jEig0][iNuFlav].re = 1.0;
-				  totalLenShiftFactor[iEig0][jEig0][iNuFlav].im = 0.;
-				}
-			    }
-			}
-		    }
-		    
-		    //============================================================================================================
-		    //DB Calculate Probability from finalTransitionMatrix
+                  const int nMaxProductionHeightBins = Constants<FLOAT_T>::MaxProdHeightBins();
+                  FLOAT_T PathLengthShifts[nMaxProductionHeightBins+1];
 
-		    /*
-		    //DB This code gives identical results to unmodified CUDAProb3
-		    UNROLLQUALIFIER
-		      for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //Flavour after osc
-			UNROLLQUALIFIER
-			  for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) { //Flavour before osc
-			    Prob[jNuFlav][iNuFlav] += finalTransitionMatrix[jNuFlav][iNuFlav].re * finalTransitionMatrix[jNuFlav][iNuFlav].re + finalTransitionMatrix[jNuFlav][iNuFlav].im * finalTransitionMatrix[jNuFlav][iNuFlav].im;
-			  }
-		      }
-		    */
+                  UNROLLQUALIFIER
+                    for (int iProductionHeight=0;iProductionHeight<(nProductionHeightBins+1);iProductionHeight++) {
+                      FLOAT_T iVal_ProdHeightInCentimeter = Constants<FLOAT_T>::km2cm() * productionHeight_binedges_list[iProductionHeight];
+                      FLOAT_T iVal_PathLength = (sqrt((Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter )*(Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter)
+                            - (Constants<FLOAT_T>::REarthcm()*Constants<FLOAT_T>::REarthcm())*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith);
 
-		    //DB B[iExp]       = A(layer = nLayers-1)  * C(layer=0)[iExp]
-		    //   Product[iExp] = finalTransitionMatrix * ExpansionMatrix[iLayerAtm][iExp]
-		    //
-		    //   math::ComplexNumber<FLOAT_T> Product[nExp][nNuFlav][nNuFlav];
-		    //   math::ComplexNumber<FLOAT_T> finalTransitionMatrix[nNuFlav][nNuFlav];
-		    //   math::ComplexNumber<FLOAT_T> ExpansionMatrix[nMaxLayers][nExp][nNuFlav][nNuFlav];
-		    for (int iExp=0;iExp<nExp;iExp++) {
-		      multiply_complex_matrix(finalTransitionMatrix,ExpansionMatrix[iLayerAtm][iExp],Product[iExp]);
-		    }
+                      PathLengthShifts[iProductionHeight] = iVal_PathLength - PathLength;
+                    }
 
-		    UNROLLQUALIFIER
-		      for (int iExp=0;iExp<nExp;iExp++) {
-			
-			UNROLLQUALIFIER
-			for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) { //Flavour before osc 
-			  UNROLLQUALIFIER
-			  for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //Flavour after osc 
-			    Prob[iNuFlav][jNuFlav] += Product[iExp][iNuFlav][jNuFlav].re * Product[iExp][iNuFlav][jNuFlav].re + Product[iExp][iNuFlav][jNuFlav].im * Product[iExp][iNuFlav][jNuFlav].im;
-			  }
-			}
+                  UNROLLQUALIFIER
+                    for (int iPathLength=0;iPathLength<nProductionHeightBins;iPathLength++) {
+                      //PathLengthShifts is of size equal to the number of Production Height bin edges
+                      FLOAT_T h0 = PathLengthShifts[iPathLength];
+                      FLOAT_T h1 = PathLengthShifts[iPathLength+1];
+                      FLOAT_T hm = (h1+h0)/2.;
+                      FLOAT_T hw = (h1-h0);
 
-			UNROLLQUALIFIER
-			  for (int jExp=0;jExp<iExp;jExp++) { //Expansion * Expansion terms
-			    UNROLLQUALIFIER
-			      for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) { //Flavour before osc
-				UNROLLQUALIFIER
-				  for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //Flavour after osc
-				    Prob[iNuFlav][jNuFlav] +=  2. * Product[jExp][iNuFlav][jNuFlav].re * Product[iExp][iNuFlav][jNuFlav].re * totalLenShiftFactor[iExp][jExp][jNuFlav].re
-				                            +  2. * Product[jExp][iNuFlav][jNuFlav].im * Product[iExp][iNuFlav][jNuFlav].im * totalLenShiftFactor[iExp][jExp][jNuFlav].re
-				                            +  2. * Product[jExp][iNuFlav][jNuFlav].im * Product[iExp][iNuFlav][jNuFlav].re * totalLenShiftFactor[iExp][jExp][jNuFlav].im
-				                            -  2. * Product[jExp][iNuFlav][jNuFlav].re * Product[iExp][iNuFlav][jNuFlav].im * totalLenShiftFactor[iExp][jExp][jNuFlav].im;
-				  }
-			      }
-			  }
-		      }
+                      UNROLLQUALIFIER
+                        for (int iEig0=0;iEig0<nEig;iEig0++) { 
+                          UNROLLQUALIFIER
+                            for (int jEig0=0;jEig0<iEig0;jEig0++) { 
+                              FLOAT_T darg_distance = darg0_ddistance[iEig0]-darg0_ddistance[jEig0];
 
-		    //============================================================================================================
-		    //DB Fill Arrays
+                              //factor.re = 0
+                              //factor.im = darg_distance*hm
+                              //
+                              //exp(factor).re = exp(f.re)*cos(f.im) = cos(darg_distance*hm)
+                              //exp(factor).im = exp(f.re)*sin(f.im) = sin(darg_distance*hm)
+                              //
+                              //sinc(0.5 * darg_distance * hw) * exp(factor).re = sinc(0.5 * darg_distance * hw) * cos(darg_distance * hm)
+                              //sinc(0.5 * darg_distance * hw) * exp(factor).re = sinc(0.5 * darg_distance * hw) * sin(darg_distance * hm)
 
-		    UNROLLQUALIFIER
-		      for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++){ //Flavour before osc
+                              math::ComplexNumber<FLOAT_T> sinc_exp_factor; 
+                              FLOAT_T Sinc_Arg = 0.5 * darg_distance * hw;
+
+                              sinc_exp_factor.re = cudaprob3::math::defined_sinc(Sinc_Arg) * cos(darg_distance * hm);
+                              sinc_exp_factor.im = cudaprob3::math::defined_sinc(Sinc_Arg) * sin(darg_distance * hm);
+
+                              UNROLLQUALIFIER
+                                for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //In flav
+
+                                  int ProbIndex = type*nNuFlav*n_energies*n_cosines*nProductionHeightBins + iNuFlav*n_energies*n_cosines*nProductionHeightBins
+                                    + index_energy*n_cosines*nProductionHeightBins + index_cosine*nProductionHeightBins + iPathLength;
+                                  //productionHeight_prob_list is of size equal to the number of production height bins * nNuTypes * nNuFlavouts * n_energies * n_cosines
+                                  FLOAT_T ProdHeightProb = productionHeight_prob_list[ProbIndex];
+
+                                  totalLenShiftFactor[iEig0][jEig0][iNuFlav].re += ProdHeightProb * sinc_exp_factor.re;
+                                  totalLenShiftFactor[iEig0][jEig0][iNuFlav].im += ProdHeightProb * sinc_exp_factor.im;
+
+                                  totalLenShiftFactor[jEig0][iEig0][iNuFlav].re += ProdHeightProb * sinc_exp_factor.re;
+                                  totalLenShiftFactor[jEig0][iEig0][iNuFlav].im -= ProdHeightProb * sinc_exp_factor.im;
+                                }
+                            }
+                        }
+                    }
+                } else {
+                  UNROLLQUALIFIER
+                    for (int iEig0=0;iEig0<nEig;iEig0++) {
+                      UNROLLQUALIFIER
+                        for (int jEig0=0;jEig0<iEig0;jEig0++) {
+                          UNROLLQUALIFIER
+                            for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) {
+                              totalLenShiftFactor[iEig0][jEig0][iNuFlav].re = 1.0;
+                              totalLenShiftFactor[iEig0][jEig0][iNuFlav].im = 0.;
+                            }
+                        }
+                    }
+                }
+
+                //============================================================================================================
+                //DB Calculate Probability from finalTransitionMatrix
+
+                /*
+                //DB This code gives identical results to unmodified CUDAProb3
+                UNROLLQUALIFIER
+                for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //Flavour after osc
+                UNROLLQUALIFIER
+                for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) { //Flavour before osc
+                Prob[jNuFlav][iNuFlav] += finalTransitionMatrix[jNuFlav][iNuFlav].re * finalTransitionMatrix[jNuFlav][iNuFlav].re + finalTransitionMatrix[jNuFlav][iNuFlav].im * finalTransitionMatrix[jNuFlav][iNuFlav].im;
+                }
+                }
+                */
+
+                //DB B[iExp]       = A(layer = nLayers-1)  * C(layer=0)[iExp]
+                //   Product[iExp] = finalTransitionMatrix * ExpansionMatrix[iLayerAtm][iExp]
+                //
+                //   math::ComplexNumber<FLOAT_T> Product[nExp][nNuFlav][nNuFlav];
+                //   math::ComplexNumber<FLOAT_T> finalTransitionMatrix[nNuFlav][nNuFlav];
+                //   math::ComplexNumber<FLOAT_T> ExpansionMatrix[nMaxLayers][nExp][nNuFlav][nNuFlav];
+                for (int iExp=0;iExp<nExp;iExp++) {
+                  multiply_complex_matrix(finalTransitionMatrix,ExpansionMatrix[iLayerAtm][iExp],Product[iExp]);
+                }
+
+                UNROLLQUALIFIER
+                  for (int iExp=0;iExp<nExp;iExp++) {
+
+                    UNROLLQUALIFIER
+                      for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) { //Flavour before osc 
                         UNROLLQUALIFIER
-                          for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++){  //Flavour after osc
+                          for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //Flavour after osc 
+                            Prob[iNuFlav][jNuFlav] += Product[iExp][iNuFlav][jNuFlav].re * Product[iExp][iNuFlav][jNuFlav].re + Product[iExp][iNuFlav][jNuFlav].im * Product[iExp][iNuFlav][jNuFlav].im;
+                          }
+                      }
+
+                    UNROLLQUALIFIER
+                      for (int jExp=0;jExp<iExp;jExp++) { //Expansion * Expansion terms
+                        UNROLLQUALIFIER
+                          for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++) { //Flavour before osc
+                            UNROLLQUALIFIER
+                              for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //Flavour after osc
+                                Prob[iNuFlav][jNuFlav] +=  2. * Product[jExp][iNuFlav][jNuFlav].re * Product[iExp][iNuFlav][jNuFlav].re * totalLenShiftFactor[iExp][jExp][jNuFlav].re
+                                  +  2. * Product[jExp][iNuFlav][jNuFlav].im * Product[iExp][iNuFlav][jNuFlav].im * totalLenShiftFactor[iExp][jExp][jNuFlav].re
+                                  +  2. * Product[jExp][iNuFlav][jNuFlav].im * Product[iExp][iNuFlav][jNuFlav].re * totalLenShiftFactor[iExp][jExp][jNuFlav].im
+                                  -  2. * Product[jExp][iNuFlav][jNuFlav].re * Product[iExp][iNuFlav][jNuFlav].im * totalLenShiftFactor[iExp][jExp][jNuFlav].im;
+                              }
+                          }
+                      }
+                  }
+
+                //============================================================================================================
+                //DB Fill Arrays
+
+                UNROLLQUALIFIER
+                  for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++){ //Flavour before osc
+                    UNROLLQUALIFIER
+                      for (int jNuFlav=0;jNuFlav<nNuFlav;jNuFlav++){  //Flavour after osc
 #ifdef __CUDA_ARCH__
-			    const unsigned long long resultIndex = (unsigned long long)(n_energies) * (unsigned long long)(index_cosine) + (unsigned long long)(index_energy);
-			    result[resultIndex + (unsigned long long)(n_energies) * (unsigned long long)(n_cosines) * (unsigned long long)((iNuFlav * nNuFlav + jNuFlav))] = Prob[jNuFlav][iNuFlav];
+                        const unsigned long long resultIndex = (unsigned long long)(n_energies) * (unsigned long long)(index_cosine) + (unsigned long long)(index_energy);
+                        result[resultIndex + (unsigned long long)(n_energies) * (unsigned long long)(n_cosines) * (unsigned long long)((iNuFlav * nNuFlav + jNuFlav))] = Prob[jNuFlav][iNuFlav];
 #else
-			    const unsigned long long resultIndex = (unsigned long long)(index_cosine) * (unsigned long long)(n_energies) * (unsigned long long)(9)
-			      + (unsigned long long)(index_energy) * (unsigned long long)(9);
-			    result[resultIndex + (unsigned long long)((iNuFlav * nNuFlav + jNuFlav))] = Prob[jNuFlav][iNuFlav];
+                        const unsigned long long resultIndex = (unsigned long long)(index_cosine) * (unsigned long long)(n_energies) * (unsigned long long)(9)
+                          + (unsigned long long)(index_energy) * (unsigned long long)(9);
+                        result[resultIndex + (unsigned long long)((iNuFlav * nNuFlav + jNuFlav))] = Prob[jNuFlav][iNuFlav];
 #endif
-			  }
-		      }
-		  }
-		}
-	      }
-	  
-            #ifdef __NVCC__
-            template<typename FLOAT_T>
+                      }
+                  }
+              }
+            }
+          }
+
+#ifdef __NVCC__
+          template<typename FLOAT_T>
             KERNEL
             __launch_bounds__( 64, 8 )
             void calculateKernel(NeutrinoType type,
-                                const FLOAT_T* const cosinelist,
-                                int n_cosines,
-                                const FLOAT_T* const energylist,
-                                int n_energies,
-                                const FLOAT_T* const radii,
-                                const FLOAT_T* const rhos,
-				const FLOAT_T* const yps,
-                                const int* const maxlayers,
-				FLOAT_T ProductionHeightinCentimeter,
-				bool useProductionHeightAveraging,
-				int nProductionHeightBins,
-				const FLOAT_T* const productionHeight_prob_list,
-				const FLOAT_T* const productionHeight_binedges_list,
-                                FLOAT_T* const result){
+                const FLOAT_T* const cosinelist,
+                int n_cosines,
+                const FLOAT_T* const energylist,
+                int n_energies,
+                const FLOAT_T* const radii,
+                const FLOAT_T* const rhos,
+                const FLOAT_T* const yps,
+                const int* const maxlayers,
+                FLOAT_T ProductionHeightinCentimeter,
+                bool useProductionHeightAveraging,
+                int nProductionHeightBins,
+                const FLOAT_T* const productionHeight_prob_list,
+                const FLOAT_T* const productionHeight_binedges_list,
+                FLOAT_T* const result){
 
-	      calculate(type, cosinelist, n_cosines, energylist, n_energies, radii, rhos, yps, maxlayers, ProductionHeightinCentimeter, useProductionHeightAveraging, nProductionHeightBins, productionHeight_prob_list, productionHeight_binedges_list, result);
+              calculate(type, 
+                  cosinelist, 
+                  n_cosines, 
+                  energylist, 
+                  n_energies, 
+                  radii, 
+                  rhos, 
+                  yps, 
+                  maxlayers, 
+                  ProductionHeightinCentimeter, 
+                  useProductionHeightAveraging, 
+                  nProductionHeightBins, 
+                  productionHeight_prob_list, 
+                  productionHeight_binedges_list, 
+                  result);
             }
 
-            template<typename FLOAT_T>
+          template<typename FLOAT_T>
             void callCalculateKernelAsync(dim3 grid,
-                                        dim3 block,
-                                        cudaStream_t stream,
-                                        NeutrinoType type,
-                                        const FLOAT_T* const cosinelist,
-                                        int n_cosines,
-                                        const FLOAT_T* const energylist,
-                                        int n_energies,
-                                        const FLOAT_T* const radii,
-                                        const FLOAT_T* const rhos,
-					const FLOAT_T* const yps,
-					const int* const maxlayers,
-				        FLOAT_T ProductionHeightinCentimeter,
-					bool useProductionHeightAveraging,
-					int nProductionHeightBins,
-		                        const FLOAT_T* const productionHeight_prob_list,
-		                        const FLOAT_T* const productionHeight_binedges_list,
-                                        FLOAT_T* const result){
+                dim3 block,
+                cudaStream_t stream,
+                NeutrinoType type,
+                const FLOAT_T* const cosinelist,
+                int n_cosines,
+                const FLOAT_T* const energylist,
+                int n_energies,
+                const FLOAT_T* const radii,
+                const FLOAT_T* const rhos,
+                const FLOAT_T* const yps,
+                const int* const maxlayers,
+                FLOAT_T ProductionHeightinCentimeter,
+                bool useProductionHeightAveraging,
+                int nProductionHeightBins,
+                const FLOAT_T* const productionHeight_prob_list,
+                const FLOAT_T* const productionHeight_binedges_list,
+                FLOAT_T* const result){
 
-                prepare_getMfast<FLOAT_T>(type);
+              prepare_getMfast<FLOAT_T>(type);
 
-                calculateKernel<FLOAT_T><<<grid, block, 0, stream>>>(type, cosinelist, n_cosines, energylist, n_energies, radii, rhos, yps, maxlayers, ProductionHeightinCentimeter, useProductionHeightAveraging, nProductionHeightBins, productionHeight_prob_list, productionHeight_binedges_list,  result);
-                CUERR;
-	    }
-            #endif
+              calculateKernel<FLOAT_T><<<grid, block, 0, stream>>>(type, cosinelist, n_cosines, energylist, n_energies, radii, rhos, yps, maxlayers, ProductionHeightinCentimeter, useProductionHeightAveraging, nProductionHeightBins, productionHeight_prob_list, productionHeight_binedges_list,  result);
+              CUERR;
+            }
+#endif
 
-	  }// namespace physics
+        }// namespace physics
 
-} // namespace cudaprob3
+      } // namespace cudaprob3
 
 
 

--- a/propagator.hpp
+++ b/propagator.hpp
@@ -30,6 +30,7 @@ along with CUDAProb3++.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdexcept>
 #include <vector>
 #include <cmath>
+#include <iostream>
 
 
 
@@ -153,7 +154,10 @@ namespace cudaprob3{
         /// @param radii_ List of radii
         /// @param rhos_ List of densities
         /// @param yps_ List of chemical compositions
-      virtual void setDensity(const std::vector<FLOAT_T>& radii_, const std::vector<FLOAT_T>& rhos_, const std::vector<FLOAT_T>& yps_){
+      virtual void setDensity(
+          const std::vector<FLOAT_T>& radii_, 
+          const std::vector<FLOAT_T>& rhos_, 
+          const std::vector<FLOAT_T>& yps_){
 
             if(rhos_.size() != radii_.size()){
                 throw std::runtime_error("setDensity : rhos.size() != radii.size()");
@@ -194,8 +198,7 @@ namespace cudaprob3{
             coslimit.clear();
 
             // first element of _Radii is largest radius
-            for(size_t i=0; i < radii.size() ; i++ )
-            {
+            for(size_t i=0; i < radii.size() ; i++ ) {
                 // Using a cosine threshold
                 FLOAT_T x = -1* sqrt( 1 - (radii[i] * radii[i] / ( Constants<FLOAT_T>::REarth()*Constants<FLOAT_T>::REarth())) );
                 if ( i  == 0 ) x = 0;
@@ -205,167 +208,311 @@ namespace cudaprob3{
             setMaxlayers();
         }
 
-        /// \brief Set density information from file
-        /// \details File must contain two columns where the first column contains the radius (km)
-        /// and the second column contains the density (g/cm³).
-        /// The first row must have the radius 0. The last row must have to radius of the sphere
-        ///
-        /// @param filename File with density information
-        virtual void setDensityFromFile(const std::string& filename){
-            std::ifstream file(filename);
-            if(!file)
-                throw std::runtime_error("could not open density file " + filename);
+        /// \brief Set density information from arrays including polynomials for a non-constant density in each layer
+        /// \details radii_ and rhos_ must be same size. both radii_ and rhos_ must be sorted, in the same order.
+        /// The density (g/cm^3) at a distance (km) from the center of the sphere between radii_[i], exclusive,
+        /// and radii_[j], inclusive, i < j  is assumed to be rhos_[j]
+        /// @param radii_ List of radii
+        /// @param a_ List of densities coefficient a
+        /// @param b_ List of densities coefficient b
+        /// @param c_ List of densities coefficient c
+        /// @param yps_ List of chemical compositions
+      virtual void setDensity(
+          const std::vector<FLOAT_T>& radii_, 
+          const std::vector<FLOAT_T>& a_, 
+          const std::vector<FLOAT_T>& b_, 
+          const std::vector<FLOAT_T>& c_, 
+          const std::vector<FLOAT_T>& yps_) {
 
-            std::vector<FLOAT_T> radii;
-            std::vector<FLOAT_T> rhos;
-	    std::vector<FLOAT_T> yps;
-            FLOAT_T r;
-            FLOAT_T d;
-	    FLOAT_T yp;
-            while (file >> r >> d >> yp){
-                radii.push_back(r);
-                rhos.push_back(d);
-		yps.push_back(yp);
+        if(a_.size() != radii_.size()){
+          throw std::runtime_error("setDensity : a.size() != radii.size()");
+        }
+
+        if(a_.size() != yps_.size()){
+          throw std::runtime_error("setDensity : a.size() != yps.size()");
+        }
+
+        if(a_.size() == 0 || b_.size() == 0 || c_.size() == 0 || radii_.size() == 0 || yps_.size() == 0){
+          throw std::runtime_error("setDensity : vectors must not be empty");
+        }
+
+        bool needFlip = false;
+
+        if(radii_.size() >= 2){
+          int sign = (radii_[1] - radii_[0] > 0 ? 1 : -1);
+
+          for(size_t i = 1; i < radii_.size(); i++){
+            if((radii_[i] - radii_[i-1]) * sign < 0)
+              throw std::runtime_error("radii order messed up");
+          }
+
+          if(sign == 1) needFlip = true;
+        }
+
+
+        // Copy over the content (probably unnecessary...)
+        radii = radii_;
+        as = a_;
+        bs = b_;
+        cs = c_;
+        yps = yps_;
+
+        if(needFlip){
+          std::reverse(radii.begin(), radii.end());
+          std::reverse(yps.begin(), yps.end());
+          std::reverse(as.begin(), as.end());
+          std::reverse(bs.begin(), bs.end());
+          std::reverse(cs.begin(), cs.end());
+        }
+
+        coslimit.clear();
+
+        // first element of _Radii is largest radius
+        for(size_t i=0; i < radii.size() ; i++ ) {
+          // Using a cosine threshold
+          FLOAT_T x = -1* sqrt( 1 - (radii[i] * radii[i] / ( Constants<FLOAT_T>::REarth()*Constants<FLOAT_T>::REarth())) );
+          if ( i  == 0 ) x = 0;
+          coslimit.push_back(x);
+        }
+
+        setMaxlayers();
+      }
+
+      /// \brief Set density information from file
+      /// \details File must contain two columns where the first column contains the radius (km)
+      /// and the second column contains the density (g/cm³).
+      /// The first row must have the radius 0. The last row must have to radius of the sphere
+      ///
+      /// @param filename File with density information
+      virtual void setDensityFromFile(const std::string& filename){
+        std::ifstream file(filename);
+        if(!file)
+          throw std::runtime_error("could not open density file " + filename);
+
+        std::vector<FLOAT_T> radii_temp;
+        std::vector<FLOAT_T> rhos_temp;
+        std::vector<FLOAT_T> yps_temp;
+
+        // First check if the file contains rho or polynomial coefficient
+        // reading the first line should suffice
+
+        std::string line;
+        int nentries_old = 0;
+        if (file.is_open()) {
+          while (std::getline(file, line)) {
+            // Allow for comments or empty lines
+            if (line[0] == '#' || line.empty()) continue;
+            // Check how many entries we have per line
+            int nentries = 0;
+            while (line.find_first_of(" ") != std::string::npos) {
+              int newpos = line.find_first_of(" ");
+              std::string substring = line.substr(0, newpos);
+              // Check repeated spaces
+              while (line[newpos] == line[newpos+1]) newpos++;
+              line = line.substr(newpos+1, line.size());
+              nentries++;
             }
-
-            setDensity(radii, rhos, yps);
+            nentries++;
+            if (nentries_old == 0) nentries_old = nentries;
+            if (nentries != nentries_old) std::cout << "Inconsitent number of entries" << std::endl;
+          }
         }
 
-        /// \brief Set mixing angles and cp phase in radians
-        /// @param theta12
-        /// @param theta13
-        /// @param theta23
-        /// @param dCP
-        virtual void setMNSMatrix(FLOAT_T theta12, FLOAT_T theta13, FLOAT_T theta23, FLOAT_T dCP){
+        std::cout << "Found " << nentries_old << " entries in file " << filename << std::endl;
+        // Reset the file reader
+        file.clear();
+        file.seekg(0);
 
-            const FLOAT_T s12 = sin(theta12);
-            const FLOAT_T s13 = sin(theta13);
-            const FLOAT_T s23 = sin(theta23);
-            const FLOAT_T c12 = cos(theta12);
-            const FLOAT_T c13 = cos(theta13);
-            const FLOAT_T c23 = cos(theta23);
+        // If the file is formatted as radius, density, electron fraction
+        if (nentries_old == 3) {
+          FLOAT_T r;
+          FLOAT_T d;
+          FLOAT_T yp;
+          while (file >> r >> d >> yp){
+            radii_temp.push_back(r);
+            rhos_temp.push_back(d);
+            yps_temp.push_back(yp);
+          }
 
-            const FLOAT_T sd  = sin(dCP);
-            const FLOAT_T cd  = cos(dCP);
+          setDensity(radii_temp, rhos_temp, yps_temp);
+        } 
+        else if (nentries_old == 5) {
 
-            U(0,0).re =  c12*c13;
-            U(0,0).im =  0.0;
-            U(0,1).re =  s12*c13;
-            U(0,1).im =  0.0;
-            U(0,2).re =  s13*cd;
-            U(0,2).im = -s13*sd;
-            U(1,0).re = -s12*c23-c12*s23*s13*cd;
-            U(1,0).im =         -c12*s23*s13*sd;
-            U(1,1).re =  c12*c23-s12*s23*s13*cd;
-            U(1,1).im =         -s12*s23*s13*sd;
-            U(1,2).re =  s23*c13;
-            U(1,2).im =  0.0;
-            U(2,0).re =  s12*s23-c12*c23*s13*cd;
-            U(2,0).im =         -c12*c23*s13*sd;
-            U(2,1).re = -c12*s23-s12*c23*s13*cd;
-            U(2,1).im  =         -s12*c23*s13*sd;
-            U(2,2).re =  c23*c13;
-            U(2,2).im  =  0.0;
-        }
+          // Coefficients of density
+          std::vector<FLOAT_T> a_temp;
+          std::vector<FLOAT_T> b_temp;
+          std::vector<FLOAT_T> c_temp;
 
-        /// \brief Set neutrino mass differences (m_i_j)^2 in (eV)^2. no assumptions about mass hierarchy are made
-        /// @param dm12sq
-        /// @param dm23sq
-        virtual void setNeutrinoMasses(FLOAT_T dm12sq, FLOAT_T dm23sq){
-            FLOAT_T mVac[3];
+          if (file.is_open()) {
+            while (std::getline(file, line)) {
+              std::vector<std::string> entries;
+              // Allow for comments or empty lines
+              if (line[0] == '#' || line.empty()) continue;
+              // Check how many entries we have per line
+              while (line.find_first_of(" ") != std::string::npos) {
+                int newpos = line.find_first_of(" ");
+                std::string substring = line.substr(0, newpos);
+                entries.push_back(substring);
+                while (line[newpos] == line[newpos+1]) newpos++;
+                line = line.substr(newpos+1, line.size());
+              }
+              entries.push_back(line);
 
-            mVac[0] = 0.0;
-            mVac[1] = dm12sq;
-            mVac[2] = dm12sq + dm23sq;
-
-            const FLOAT_T delta = 5.0e-9;
-            /* Break any degeneracies */
-            if (dm12sq == 0.0) mVac[0] -= delta;
-            if (dm23sq == 0.0) mVac[2] += delta;
-
-            DM(0,0) = 0.0;
-            DM(1,1) = 0.0;
-            DM(2,2) = 0.0;
-            DM(0,1) = mVac[0]-mVac[1];
-            DM(1,0) = -DM(0,1);
-            DM(0,2) = mVac[0]-mVac[2];
-            DM(2,0) = -DM(0,2);
-            DM(1,2) = mVac[1]-mVac[2];
-            DM(2,1) = -DM(1,2);
-
-        }
-
-        /// \brief Set the energy bins. Energies are given in GeV
-        /// @param list Energy list
-        virtual void setEnergyList(const std::vector<FLOAT_T>& list){
-            if(list.size() != size_t(n_energies))
-                throw std::runtime_error("Propagator::setEnergyList. Propagator was not created for this number of energy nodes");
-
-            energyList = list;
-        }
-
-        /// \brief Set cosine bins. Cosines are given in radians
-        /// @param list Cosine list
-        virtual void setCosineList(const std::vector<FLOAT_T>& list){
-            if(list.size() != size_t(n_cosines))
-                throw std::runtime_error("Propagator::setCosineList. Propagator was not created for this number of cosine nodes");
-
-            cosineList = list;
-
-            if(isSetProductionHeight){
-                setProductionHeight(ProductionHeightinCentimeter / 100000.0);
+              // Now push back into our main vectors
+              radii_temp.push_back(std::atof(entries[0].c_str()));
+              a_temp.push_back(std::atof(entries[1].c_str()));
+              b_temp.push_back(std::atof(entries[2].c_str()));
+              c_temp.push_back(std::atof(entries[3].c_str()));
+              yps_temp.push_back(std::atof(entries[4].c_str()));
             }
+          }
+          //for (int i = 0; i < nentries_old; ++i) {
+            //std::cout << radii_temp[i] << " " << a_temp[i] << " " << b_temp[i] << " " << c_temp[i] << " " << yps_temp[i] << std::endl;
+          //}
 
-            setMaxlayers();
+          setDensity(radii_temp, a_temp, b_temp, c_temp, yps_temp);
 
-            isSetCosine = true;
+        } else {
+          std::cout << "Unsupported earty model in " << filename << std::endl;
+          std::cout << "  Number of entries per line: " << nentries_old << std::endl;
+          throw;
+        }
+      }
+
+      /// \brief Set mixing angles and cp phase in radians
+      /// @param theta12
+      /// @param theta13
+      /// @param theta23
+      /// @param dCP
+      virtual void setMNSMatrix(FLOAT_T theta12, FLOAT_T theta13, FLOAT_T theta23, FLOAT_T dCP){
+
+        const FLOAT_T s12 = sin(theta12);
+        const FLOAT_T s13 = sin(theta13);
+        const FLOAT_T s23 = sin(theta23);
+        const FLOAT_T c12 = cos(theta12);
+        const FLOAT_T c13 = cos(theta13);
+        const FLOAT_T c23 = cos(theta23);
+
+        const FLOAT_T sd  = sin(dCP);
+        const FLOAT_T cd  = cos(dCP);
+
+        U(0,0).re =  c12*c13;
+        U(0,0).im =  0.0;
+        U(0,1).re =  s12*c13;
+        U(0,1).im =  0.0;
+        U(0,2).re =  s13*cd;
+        U(0,2).im = -s13*sd;
+        U(1,0).re = -s12*c23-c12*s23*s13*cd;
+        U(1,0).im =         -c12*s23*s13*sd;
+        U(1,1).re =  c12*c23-s12*s23*s13*cd;
+        U(1,1).im =         -s12*s23*s13*sd;
+        U(1,2).re =  s23*c13;
+        U(1,2).im =  0.0;
+        U(2,0).re =  s12*s23-c12*c23*s13*cd;
+        U(2,0).im =         -c12*c23*s13*sd;
+        U(2,1).re = -c12*s23-s12*c23*s13*cd;
+        U(2,1).im  =         -s12*c23*s13*sd;
+        U(2,2).re =  c23*c13;
+        U(2,2).im  =  0.0;
+      }
+
+      /// \brief Set neutrino mass differences (m_i_j)^2 in (eV)^2. no assumptions about mass hierarchy are made
+      /// @param dm12sq
+      /// @param dm23sq
+      virtual void setNeutrinoMasses(FLOAT_T dm12sq, FLOAT_T dm23sq){
+        FLOAT_T mVac[3];
+
+        mVac[0] = 0.0;
+        mVac[1] = dm12sq;
+        mVac[2] = dm12sq + dm23sq;
+
+        const FLOAT_T delta = 5.0e-9;
+        /* Break any degeneracies */
+        if (dm12sq == 0.0) mVac[0] -= delta;
+        if (dm23sq == 0.0) mVac[2] += delta;
+
+        DM(0,0) = 0.0;
+        DM(1,1) = 0.0;
+        DM(2,2) = 0.0;
+        DM(0,1) = mVac[0]-mVac[1];
+        DM(1,0) = -DM(0,1);
+        DM(0,2) = mVac[0]-mVac[2];
+        DM(2,0) = -DM(0,2);
+        DM(1,2) = mVac[1]-mVac[2];
+        DM(2,1) = -DM(1,2);
+      }
+
+      /// \brief Set the energy bins. Energies are given in GeV
+      /// @param list Energy list
+      virtual void setEnergyList(const std::vector<FLOAT_T>& list){
+        if(list.size() != size_t(n_energies))
+          throw std::runtime_error("Propagator::setEnergyList. Propagator was not created for this number of energy nodes");
+
+        energyList = list;
+      }
+
+      /// \brief Set cosine bins. Cosines are given in radians
+      /// @param list Cosine list
+      virtual void setCosineList(const std::vector<FLOAT_T>& list){
+        if(list.size() != size_t(n_cosines))
+          throw std::runtime_error("Propagator::setCosineList. Propagator was not created for this number of cosine nodes");
+
+        cosineList = list;
+
+        if(isSetProductionHeight){
+          setProductionHeight(ProductionHeightinCentimeter / 100000.0);
         }
 
-        /// \brief Set production height in km of neutrinos
-        /// \details Adds a layer of length heightKM with zero density to the density model
-        /// @param heightKM Set neutrino production height
-        virtual void setProductionHeight(FLOAT_T heightKM){
-            if(!isSetCosine)
-                throw std::runtime_error("must set cosine list before production height");
+        setMaxlayers();
 
-            ProductionHeightinCentimeter = heightKM * 100000.0;
+        isSetCosine = true;
+      }
 
-            isSetProductionHeight = true;
-        }
+      /// \brief Set production height in km of neutrinos
+      /// \details Adds a layer of length heightKM with zero density to the density model
+      /// @param heightKM Set neutrino production height
+      virtual void setProductionHeight(FLOAT_T heightKM){
+        if(!isSetCosine)
+          throw std::runtime_error("must set cosine list before production height");
+
+        ProductionHeightinCentimeter = heightKM * 100000.0;
+
+        isSetProductionHeight = true;
+      }
 
       virtual void setProductionHeightList(const std::vector<FLOAT_T>& list_prob, const std::vector<FLOAT_T>& list_bins) {
-	if (!this->useProductionHeightAveraging) {
-	  throw std::runtime_error("Propagator::setProductionHeightList. Trying to set Production Height information but propagator is not expecting to use it");
-	}
+        if (!this->useProductionHeightAveraging) {
+          throw std::runtime_error("Propagator::setProductionHeightList. Trying to set Production Height information but propagator is not expecting to use it");
+        }
 
-	if (list_prob.size() != this->nProductionHeightBins*2*3*n_energies*n_cosines) {
-	  throw std::runtime_error("Propagator::setProductionHeightList. Prob array is not the expected size");
-	}
-          
-	if (list_bins.size()-1 != this->nProductionHeightBins) {
-	  throw std::runtime_error("Propagator::setProductionHeightList. ProductionHeightBins array is not expected size");
-	}
+        if (list_prob.size() != this->nProductionHeightBins*2*3*n_energies*n_cosines) {
+          throw std::runtime_error("Propagator::setProductionHeightList. Prob array is not the expected size");
+        }
 
-	int MaxSize = Constants<FLOAT_T>::MaxProdHeightBins()*2*3*n_energies*n_cosines;
-	productionHeightList_prob = std::vector<FLOAT_T>(MaxSize);
-	for (unsigned int i=0;i<MaxSize;i++) {
-	  productionHeightList_prob[i] = 0.;
-	}
+        if (list_bins.size()-1 != this->nProductionHeightBins) {
+          throw std::runtime_error("Propagator::setProductionHeightList. ProductionHeightBins array is not expected size");
+        }
 
-	for (unsigned int i=0;i<list_prob.size();i++) {
-	  productionHeightList_prob[i] = list_prob[i];
-	}
+        int MaxSize = Constants<FLOAT_T>::MaxProdHeightBins()*2*3*n_energies*n_cosines;
+        productionHeightList_prob = std::vector<FLOAT_T>(MaxSize);
+        for (unsigned int i=0;i<MaxSize;i++) {
+          productionHeightList_prob[i] = 0.;
+        }
 
-	productionHeightList_bins = std::vector<FLOAT_T>(Constants<FLOAT_T>::MaxProdHeightBins()+1);
-	for (unsigned int i=0;i<Constants<FLOAT_T>::MaxProdHeightBins();i++) {
-	  productionHeightList_bins[i] = 0.;
-	}
+        for (unsigned int i=0;i<list_prob.size();i++) {
+          productionHeightList_prob[i] = list_prob[i];
+        }
 
-	for (unsigned int i=0;i<list_bins.size();i++) {
-	  productionHeightList_bins[i] = list_bins[i];
-	}
-	
-	isSetProductionHeightArray = true;
+        productionHeightList_bins = std::vector<FLOAT_T>(Constants<FLOAT_T>::MaxProdHeightBins()+1);
+        for (unsigned int i=0;i<Constants<FLOAT_T>::MaxProdHeightBins();i++) {
+          productionHeightList_bins[i] = 0.;
+        }
+
+        for (unsigned int i=0;i<list_bins.size();i++) {
+          productionHeightList_bins[i] = list_bins[i];
+        }
+
+        isSetProductionHeightArray = true;
       }
 
       /// \brief Set chemical composition of each layer in the Earth model
@@ -373,75 +520,78 @@ namespace cudaprob3{
       /// @param
       virtual void setChemicalComposition(const std::vector<FLOAT_T>& list) = 0;
 
-        /// \brief Calculate the probability of each cell
-        /// @param type Neutrino or Antineutrino
-        virtual void calculateProbabilities(NeutrinoType type) = 0;
+      /// \brief Calculate the probability of each cell
+      /// @param type Neutrino or Antineutrino
+      virtual void calculateProbabilities(NeutrinoType type) = 0;
 
-        /// \brief get oscillation weight for specific cosine and energy
-        /// @param index_cosine Cosine bin index (zero based)
-        /// @param index_energy Energy bin index (zero based)
-        /// @param t Specify which probability P(i->j)
-        virtual FLOAT_T getProbability(int index_cosine, int index_energy, ProbType t) = 0;
+      /// \brief get oscillation weight for specific cosine and energy
+      /// @param index_cosine Cosine bin index (zero based)
+      /// @param index_energy Energy bin index (zero based)
+      /// @param t Specify which probability P(i->j)
+      virtual FLOAT_T getProbability(int index_cosine, int index_energy, ProbType t) = 0;
 
-        /// \brief get oscillation weight
-        /// @param probArr Cosine bin index (zero based)
-        /// @param t Specify which probability P(i->j)
-        virtual void getProbabilityArr(FLOAT_T* probArr, ProbType t) = 0;
+      /// \brief get oscillation weight
+      /// @param probArr Cosine bin index (zero based)
+      /// @param t Specify which probability P(i->j)
+      virtual void getProbabilityArr(FLOAT_T* probArr, ProbType t) = 0;
 
     protected:
-        // for each cosine bin, determine the number of layers which will be crossed by the neutrino path
-        // the atmospheric layers is excluded
-        virtual void setMaxlayers(){
-            for(int index_cosine = 0; index_cosine < n_cosines; index_cosine++){
-                FLOAT_T c = cosineList[index_cosine];
-                const int maxLayer = std::count_if(coslimit.begin(), coslimit.end(), [c](FLOAT_T limit){ return c < limit;});
+      // for each cosine bin, determine the number of layers which will be crossed by the neutrino path
+      // the atmospheric layers is excluded
+      virtual void setMaxlayers(){
+        for(int index_cosine = 0; index_cosine < n_cosines; index_cosine++){
+          FLOAT_T c = cosineList[index_cosine];
+          const int maxLayer = std::count_if(coslimit.begin(), coslimit.end(), [c](FLOAT_T limit){ return c < limit;});
 
-		if (maxLayer > Constants<FLOAT_T>::MaxNLayers()) {
-		  std::cerr << "Invalid number of maxLayer:" << maxLayer << std::endl;
-		  std::cerr << "Need to increase value of Constants<FLOAT_T>::MaxNLayers() in $CUDAPROB3/constants.hpp" << std::endl;
-		  throw std::runtime_error("setMaxlayers : invalid number of maxLayer");
-		}
+          if (maxLayer > Constants<FLOAT_T>::MaxNLayers()) {
+            std::cerr << "Invalid number of maxLayer:" << maxLayer << std::endl;
+            std::cerr << "Need to increase value of Constants<FLOAT_T>::MaxNLayers() in $CUDAPROB3/constants.hpp" << std::endl;
+            throw std::runtime_error("setMaxlayers : invalid number of maxLayer");
+          }
 
-                maxlayers[index_cosine] = maxLayer;
-            }
+          maxlayers[index_cosine] = maxLayer;
         }
+      }
 
-        cudaprob3::math::ComplexNumber<FLOAT_T>& U(int i, int j){
-            return Mix_U[( i * 3 + j)];
-        }
+      cudaprob3::math::ComplexNumber<FLOAT_T>& U(int i, int j){
+        return Mix_U[( i * 3 + j)];
+      }
 
-        FLOAT_T& DM(int i, int j){
-            return dm[( i * 3 + j)];
-        }
+      FLOAT_T& DM(int i, int j){
+        return dm[( i * 3 + j)];
+      }
 
-        std::vector<FLOAT_T> energyList;
-        std::vector<FLOAT_T> cosineList;
-        std::vector<int> maxlayers;
-        //std::vector<FLOAT_T> pathLengths;
+      std::vector<FLOAT_T> energyList;
+      std::vector<FLOAT_T> cosineList;
+      std::vector<int> maxlayers;
+      //std::vector<FLOAT_T> pathLengths;
 
-        std::vector<FLOAT_T> productionHeightList_prob;
-        std::vector<FLOAT_T> productionHeightList_bins;
+      std::vector<FLOAT_T> productionHeightList_prob;
+      std::vector<FLOAT_T> productionHeightList_bins;
 
-        std::vector<FLOAT_T> radii;
-        std::vector<FLOAT_T> rhos;
-        std::vector<FLOAT_T> yps;
-        std::vector<FLOAT_T> coslimit;
+      std::vector<FLOAT_T> radii;
+      std::vector<FLOAT_T> rhos;
+      std::vector<FLOAT_T> as;
+      std::vector<FLOAT_T> bs;
+      std::vector<FLOAT_T> cs;
+      std::vector<FLOAT_T> yps;
+      std::vector<FLOAT_T> coslimit;
 
-        std::array<cudaprob3::math::ComplexNumber<FLOAT_T>, 9> Mix_U; // MNS mixing matrix
-        std::array<FLOAT_T, 9> dm; // mass differences;
+      std::array<cudaprob3::math::ComplexNumber<FLOAT_T>, 9> Mix_U; // MNS mixing matrix
+      std::array<FLOAT_T, 9> dm; // mass differences;
 
-        FLOAT_T ProductionHeightinCentimeter;
+      FLOAT_T ProductionHeightinCentimeter;
 
-        bool useProductionHeightAveraging = false;
-        int nProductionHeightBins = 0;
+      bool useProductionHeightAveraging = false;
+      int nProductionHeightBins = 0;
 
-        bool isSetProductionHeightArray = false;
-        bool isSetProductionHeight = false;
-        bool isSetCosine = false;
-        bool isInit = true;
+      bool isSetProductionHeightArray = false;
+      bool isSetProductionHeight = false;
+      bool isSetCosine = false;
+      bool isInit = true;
 
-        int n_cosines;
-        int n_energies;
+      int n_cosines;
+      int n_energies;
     };
 
 

--- a/propagator.hpp
+++ b/propagator.hpp
@@ -76,6 +76,9 @@ namespace cudaprob3{
             maxlayers = other.maxlayers;
             radii = other.radii;
             rhos = other.rhos;
+            as = other.as;
+            bs = other.bs;
+            cs = other.cs;
 	    yps = other.yps;
             coslimit = other.coslimit;
             Mix_U = other.Mix_U;
@@ -104,6 +107,9 @@ namespace cudaprob3{
             maxlayers = std::move(other.maxlayers);
             radii = std::move(other.radii);
             rhos = std::move(other.rhos);
+            as = std::move(other.as);
+            bs = std::move(other.bs);
+            cs = std::move(other.cs);
 	    yps = std::move(other.yps);
             coslimit = std::move(other.coslimit);
             Mix_U = std::move(other.Mix_U);
@@ -158,6 +164,8 @@ namespace cudaprob3{
           const std::vector<FLOAT_T>& radii_, 
           const std::vector<FLOAT_T>& rhos_, 
           const std::vector<FLOAT_T>& yps_){
+
+          UsePolyDensity = false;
 
             if(rhos_.size() != radii_.size()){
                 throw std::runtime_error("setDensity : rhos.size() != radii.size()");
@@ -223,6 +231,8 @@ namespace cudaprob3{
           const std::vector<FLOAT_T>& b_, 
           const std::vector<FLOAT_T>& c_, 
           const std::vector<FLOAT_T>& yps_) {
+
+        UsePolyDensity = true;
 
         if(a_.size() != radii_.size()){
           throw std::runtime_error("setDensity : a.size() != radii.size()");
@@ -592,6 +602,9 @@ namespace cudaprob3{
 
       int n_cosines;
       int n_energies;
+
+      // Use polynomial density for density averaging each track?
+      bool UsePolyDensity;
     };
 
 


### PR DESCRIPTION
Uses a polynomial density for each earth layer instead of constant density treatment, both from PREM model. The polynomial density is averaged over each costheta slice in `getDensityPoly` in `physics.hpp`. 

With PREM4 polynomial density, we only add 4 * 3 (layers * polynomial coefficients) `float` or `double`, and calculation is relatively fast. Could instead move to pre-calculating them, but that would involve caching more memory. 

The propagator class reads the input density, using setDensityFromFile as usual. It now allows for comments, and can run with the usual PREM 4 layer density, or the updated polynomial PREM 4 layer density. The other PREM models are supported once the relative electron fraction (e.g. 0.468) is added to those files.

All other capability is maintained, e.g. setting the chemical composition (relative electron fraction). 

CPU, GPU, float and double code has been validated, and files are attached.

CPU only, average vs PREM 4 constant:
[Oscillograms_avg_dens_CPU.root_Oscillograms_PREM4.root.pdf](https://github.com/dbarrow257/CUDAProb3/files/7478062/Oscillograms_avg_dens_CPU.root_Oscillograms_PREM4.root.pdf)

GPU vs CPU with double precision, using average density:
[Oscillograms_avg_dens_GPU.root_Oscillograms_avg_dens_CPU.root.pdf](https://github.com/dbarrow257/CUDAProb3/files/7478070/Oscillograms_avg_dens_GPU.root_Oscillograms_avg_dens_CPU.root.pdf)

