### PR TITLE
Allowing to set a different Earth radius

### DIFF
--- a/constants.hpp
+++ b/constants.hpp
@@ -22,6 +22,8 @@ along with CUDAProb3++.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace cudaprob3{
 
+    double EarthRadius = 6371.0;
+    
     template<typename FLOAT_T>
     struct Constants{
         HOSTDEVICEQUALIFIER
@@ -31,7 +33,10 @@ namespace cudaprob3{
         static constexpr FLOAT_T km2cm(){ return 1.0e5; }
 
         HOSTDEVICEQUALIFIER
-        static constexpr FLOAT_T REarth(){ return 6371.0; }
+        static void SetEarthRadius(FLOAT_T EarthRadius_){ EarthRadius = EarthRadius_; }
+
+        HOSTDEVICEQUALIFIER
+        static constexpr FLOAT_T REarth(){ return EarthRadius; }
 
         HOSTDEVICEQUALIFIER
         static constexpr FLOAT_T REarthcm(){ return REarth() * km2cm(); }
@@ -43,7 +48,7 @@ namespace cudaprob3{
         static constexpr int MaxProdHeightBins(){ return 28; }
 
         HOSTDEVICEQUALIFIER
-        static constexpr int MaxNLayers(){ return 10; }
+        static constexpr int MaxNLayers(){ return 11; }
       
         HOSTDEVICEQUALIFIER
 	static constexpr FLOAT_T Epsilon(){ return 1e-6; }

--- a/constants.hpp
+++ b/constants.hpp
@@ -22,6 +22,7 @@ along with CUDAProb3++.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace cudaprob3{
 
+    HOSTDEVICEQUALIFIER
     FLOAT_T EarthRadius = 6371.0;
     
     template<typename FLOAT_T>

--- a/constants.hpp
+++ b/constants.hpp
@@ -22,7 +22,7 @@ along with CUDAProb3++.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace cudaprob3{
 
-    double EarthRadius = 6371.0;
+    FLOAT_T EarthRadius = 6371.0;
     
     template<typename FLOAT_T>
     struct Constants{

--- a/propagator.hpp
+++ b/propagator.hpp
@@ -79,7 +79,8 @@ namespace cudaprob3{
             as = other.as;
             bs = other.bs;
             cs = other.cs;
-	    yps = other.yps;
+            ws = other.ws;
+	          yps = other.yps;
             coslimit = other.coslimit;
             Mix_U = other.Mix_U;
             dm = other.dm;
@@ -110,6 +111,7 @@ namespace cudaprob3{
             as = std::move(other.as);
             bs = std::move(other.bs);
             cs = std::move(other.cs);
+            ws = std::move(other.ws);
 	    yps = std::move(other.yps);
             coslimit = std::move(other.coslimit);
             Mix_U = std::move(other.Mix_U);
@@ -387,6 +389,7 @@ namespace cudaprob3{
 
           setDensity(radii_temp, a_temp, b_temp, c_temp, yps_temp);
 
+
         } else {
           std::cout << "Unsupported earty model in " << filename << std::endl;
           std::cout << "  Number of entries per line: " << nentries_old << std::endl;
@@ -396,6 +399,12 @@ namespace cudaprob3{
       }
 
       virtual void ModifyEarthModelPoly(std::vector<FLOAT_T> list_radii, std::vector<FLOAT_T> list_weights){
+
+        if(ws.size()==0){
+          std::vector<FLOAT_T> w_temp(list_weights.size(), 1.0f); 
+          ws=w_temp;
+        }
+
         Constants<FLOAT_T>::SetEarthRadius(list_radii[list_radii.size() - 1]);
         int nBoundaries(list_radii.size());
         int nWeights(list_weights.size());
@@ -412,18 +421,26 @@ namespace cudaprob3{
         }
 
         for(int i=0;i<nWeights;i++){
-          as[i]*= list_weights[nWeights-i-1];
-          bs[i]*= list_weights[nWeights-i-1];
-          cs[i]*= list_weights[nWeights-i-1];
+          as[i]*= list_weights[nWeights-i-1]/ws[nWeights-i-1];
+          bs[i]*= list_weights[nWeights-i-1]/ws[nWeights-i-1];
+          cs[i]*= list_weights[nWeights-i-1]/ws[nWeights-i-1];
         }
-        as[nWeights]*= list_weights[0];
-        bs[nWeights]*= list_weights[0];
-        cs[nWeights]*= list_weights[0];
+        as[nWeights]*= list_weights[0]/ws[0];
+        bs[nWeights]*= list_weights[0]/ws[0];
+        cs[nWeights]*= list_weights[0]/ws[0];
+
+        ws = list_weights;
 
         setDensity(radii, as, bs, cs, yps);
       }
 
       virtual void ModifyEarthModel(std::vector<FLOAT_T> list_radii, std::vector<FLOAT_T> list_weights){
+
+        if(ws.size()==0){
+          std::vector<FLOAT_T> w_temp(list_weights.size(), 1.0f); 
+          ws=w_temp;
+        }
+
         Constants<FLOAT_T>::SetEarthRadius(list_radii[list_radii.size() - 1]);
         int nBoundaries(list_radii.size());
         int nWeights(list_weights.size());
@@ -440,9 +457,11 @@ namespace cudaprob3{
         }
         
         for(int i=0;i<nWeights;i++){
-          rhos[i]*= list_weights[nWeights-i-1];
+          rhos[i]*= list_weights[nWeights-i-1]/ws[nWeights-i-1];
         }
-        rhos[nWeights]*= list_weights[0];
+        rhos[nWeights]*= list_weights[0]/ws[0];
+
+        ws = list_weights;
 
         setDensity(radii, rhos, yps);
       }
@@ -646,6 +665,7 @@ namespace cudaprob3{
       std::vector<FLOAT_T> as;
       std::vector<FLOAT_T> bs;
       std::vector<FLOAT_T> cs;
+      std::vector<FLOAT_T> ws;
       std::vector<FLOAT_T> yps;
       std::vector<FLOAT_T> coslimit;
 

--- a/propagator.hpp
+++ b/propagator.hpp
@@ -420,14 +420,19 @@ namespace cudaprob3{
           radii[i] = list_radii[nBoundaries-i-1];
         }
 
+        FLOAT_T tmp_weights_ratio(1);
+
         for(int i=0;i<nWeights;i++){
-          as[i]*= list_weights[nWeights-i-1]/ws[nWeights-i-1];
-          bs[i]*= list_weights[nWeights-i-1]/ws[nWeights-i-1];
-          cs[i]*= list_weights[nWeights-i-1]/ws[nWeights-i-1];
+          tmp_weights_ratio = list_weights[nWeights-i-1]/ws[nWeights-i-1];
+          as[i]*= tmp_weights_ratio;
+          bs[i]*= tmp_weights_ratio;
+          cs[i]*= tmp_weights_ratio;
         }
-        as[nWeights]*= list_weights[0]/ws[0];
-        bs[nWeights]*= list_weights[0]/ws[0];
-        cs[nWeights]*= list_weights[0]/ws[0];
+
+        tmp_weights_ratio = list_weights[0]/ws[0];
+        as[nWeights]*= tmp_weights_ratio;
+        bs[nWeights]*= tmp_weights_ratio;
+        cs[nWeights]*= tmp_weights_ratio;
 
         ws = list_weights;
 

--- a/propagator.hpp
+++ b/propagator.hpp
@@ -396,7 +396,7 @@ namespace cudaprob3{
       }
 
       virtual void ModifyEarthModelPoly(std::vector<FLOAT_T> list_radii, std::vector<FLOAT_T> list_weights){
-        
+        Constants<FLOAT_T>::SetEarthRadius(list_radii[list_radii.size() - 1]);
         int nBoundaries(list_radii.size());
         int nWeights(list_weights.size());
 
@@ -424,7 +424,7 @@ namespace cudaprob3{
       }
 
       virtual void ModifyEarthModel(std::vector<FLOAT_T> list_radii, std::vector<FLOAT_T> list_weights){
-
+        Constants<FLOAT_T>::SetEarthRadius(list_radii[list_radii.size() - 1]);
         int nBoundaries(list_radii.size());
         int nWeights(list_weights.size());
 
@@ -615,7 +615,7 @@ namespace cudaprob3{
           FLOAT_T c = cosineList[index_cosine];
           const int maxLayer = std::count_if(coslimit.begin(), coslimit.end(), [c](FLOAT_T limit){ return c < limit;});
 
-          if (maxLayer > Constants<FLOAT_T>::MaxNLayers()) {
+          if (maxLayer >= Constants<FLOAT_T>::MaxNLayers()) {
             std::cerr << "Invalid number of maxLayer:" << maxLayer << std::endl;
             std::cerr << "Need to increase value of Constants<FLOAT_T>::MaxNLayers() in $CUDAPROB3/constants.hpp" << std::endl;
             throw std::runtime_error("setMaxlayers : invalid number of maxLayer");


### PR DESCRIPTION
Allowing to reset the Earth radius. When `ModifyEarthModel` was called with a total radius less than 6371.0 the probabilities in that region were invalid:

![P_ee_Model4](https://github.com/user-attachments/assets/0ee41e39-1278-450d-b346-e4ce720d8e1e)

The fix seems to have solved this issue:

![P_ee_Model4_n](https://github.com/user-attachments/assets/4cdc15f1-0b06-472f-bbf1-e87419fb13ea)
