### PR TITLE
Explicitly Set Earth Radius in Propagator initializer

### DIFF
--- a/propagator.hpp
+++ b/propagator.hpp
@@ -52,6 +52,9 @@ namespace cudaprob3{
             energyList.resize(n_energies);
             cosineList.resize(n_cosines);
             maxlayers.resize(n_cosines);
+
+            // Set EarthRadius explicitly for CUDA
+            Constants<FLOAT_T>::SetEarthRadius(6371.0);
         }
 
         /// \brief Copy constructor


### PR DESCRIPTION
Otherwise in the CUDA build, the earth radius is uninitialized [here](https://github.com/dbarrow257/CUDAProb3/blob/e910bff2e41e9977a94f76ac9968cd515192dab9/propagator.hpp#L155), but I don't know CUDA well enough to understand why the initialization in the declaration alone doesn't work.

This issue was found when trying to understand why event rates for [MaCh3_DUNE](https://github.com/DUNE/MaCh3_DUNE) atmospherics changed.