### PR TITLE
Remove annoing warning

### DIFF
--- a/constants.hpp
+++ b/constants.hpp
@@ -22,9 +22,33 @@ along with CUDAProb3++.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace cudaprob3{
 
+    // KS This terrible piece of pragmas is to supress very annoying warnings when compiling code
+    #if defined(__CUDACC__)
+    #pragma diag_push
+    #pragma diag_suppress=1835
+    #endif
+
+    #if defined(__clang__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wattributes"
+    #elif defined(__GNUC__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wattributes"
+    #endif
+
     HOSTDEVICEQUALIFIER
     FLOAT_T EarthRadius = 6371.0;
-    
+
+    #if defined(__clang__)
+    #pragma clang diagnostic pop
+    #elif defined(__GNUC__)
+    #pragma GCC diagnostic pop
+    #endif
+
+    #if defined(__CUDACC__)
+    #pragma diag_pop
+    #endif
+
     template<typename FLOAT_T>
     struct Constants{
         HOSTDEVICEQUALIFIER


### PR DESCRIPTION
This warning is SPAMMING terrible GPU compilation of NuOsc and MaCh3.
Since it is in header you are getting spammed beyond oblviion

What is annoing is that this warning is misleading.

before
<img width="966" alt="test" src="https://github.com/user-attachments/assets/a05bb715-e92d-42c7-a16c-385afab43705" />

after
![image](https://github.com/user-attachments/assets/92a289d3-d9a8-486c-a54e-ee03848d5a42)
