### PR TITLE
Cracky Speed Up

### DIFF
--- a/constants.hpp
+++ b/constants.hpp
@@ -67,6 +67,12 @@ namespace cudaprob3{
         static constexpr FLOAT_T REarthcm(){ return REarth() * km2cm(); }
 
         HOSTDEVICEQUALIFIER
+        static constexpr FLOAT_T REarthcm2(){ return REarthcm() * REarthcm(); }
+
+        HOSTDEVICEQUALIFIER
+        static constexpr FLOAT_T TwoPiOverThree() { return 2.0 * M_PI / 3.0; }
+
+        HOSTDEVICEQUALIFIER
         static constexpr FLOAT_T density_convert(){ return 0.5; }
 
         HOSTDEVICEQUALIFIER

--- a/cpupropagator.hpp
+++ b/cpupropagator.hpp
@@ -109,7 +109,7 @@ namespace cudaprob3{
                 this->useProductionHeightAveraging,
                 this->nProductionHeightBins,
                 this->productionHeightList_prob.data(), 
-                this->productionHeightList_bins.data(), 
+                this->productionHeightList_paths.data(),
                 this->UsePolyDensity, // Are we using constant density or polynomial?
                 resultList.data());
         }

--- a/cpupropagator.hpp
+++ b/cpupropagator.hpp
@@ -109,7 +109,7 @@ namespace cudaprob3{
                 this->useProductionHeightAveraging,
                 this->nProductionHeightBins,
                 this->productionHeightList_prob.data(), 
-                this->productionHeightList_paths.data(),
+                this->productionHeightList_hm_hw.data(),
                 this->UsePolyDensity, // Are we using constant density or polynomial?
                 resultList.data());
         }

--- a/cudapropagator.cuh
+++ b/cudapropagator.cuh
@@ -203,7 +203,7 @@ namespace cudaprob3{
           Propagator<FLOAT_T>::setProductionHeightList(list_prob, list_bins); //set host production height list
 
           cudaMemcpy(d_productionHeight_prob_list.get(), this->productionHeightList_prob.data(), sizeof(FLOAT_T)*Constants<FLOAT_T>::MaxProdHeightBins()*2*3*this->n_energies*this->n_cosines, H2D); CUERR;
-          cudaMemcpy(d_productionHeight_bins_list.get(), this->productionHeightList_bins.data(), sizeof(FLOAT_T)*(Constants<FLOAT_T>::MaxProdHeightBins()+1), H2D); CUERR;
+          cudaMemcpy(d_productionHeightList_paths.get(), this->productionHeightList_paths.data(), sizeof(FLOAT_T)*(Constants<FLOAT_T>::MaxProdHeightBins()+1)*this->n_cosines , H2D); CUERR;
         }
 
         // calculate the probability of each cell
@@ -311,7 +311,7 @@ namespace cudaprob3{
               this->useProductionHeightAveraging,
               this->nProductionHeightBins,
               d_productionHeight_prob_list.get(),
-              d_productionHeight_bins_list.get(),
+              d_productionHeightList_paths.get(),
               this->UsePolyDensity,
               d_result_list.get());
 
@@ -349,7 +349,7 @@ namespace cudaprob3{
         unique_dev_ptr<FLOAT_T> d_energy_list;
         unique_dev_ptr<FLOAT_T> d_cosine_list;
         unique_dev_ptr<FLOAT_T> d_productionHeight_prob_list;
-        unique_dev_ptr<FLOAT_T> d_productionHeight_bins_list;
+        unique_dev_ptr<FLOAT_T> d_productionHeightList_paths;
         shared_dev_ptr<FLOAT_T> d_result_list;
 
         cudaStream_t stream;

--- a/cudapropagator.cuh
+++ b/cudapropagator.cuh
@@ -203,7 +203,7 @@ namespace cudaprob3{
           Propagator<FLOAT_T>::setProductionHeightList(list_prob, list_bins); //set host production height list
 
           cudaMemcpy(d_productionHeight_prob_list.get(), this->productionHeightList_prob.data(), sizeof(FLOAT_T)*Constants<FLOAT_T>::MaxProdHeightBins()*2*3*this->n_energies*this->n_cosines, H2D); CUERR;
-          cudaMemcpy(d_productionHeightList_paths.get(), this->productionHeightList_paths.data(), sizeof(FLOAT_T)*(Constants<FLOAT_T>::MaxProdHeightBins()+1)*this->n_cosines , H2D); CUERR;
+          cudaMemcpy(d_productionHeightList_hm_hw.get(), this->productionHeightList_hm_hw.data(), sizeof(FLOAT_T) * Constants<FLOAT_T>::MaxProdHeightBins() * this->n_cosines * 2, H2D); CUERR;
         }
 
         // calculate the probability of each cell
@@ -311,7 +311,7 @@ namespace cudaprob3{
               this->useProductionHeightAveraging,
               this->nProductionHeightBins,
               d_productionHeight_prob_list.get(),
-              d_productionHeightList_paths.get(),
+              d_productionHeightList_hm_hw.get(),
               this->UsePolyDensity,
               d_result_list.get());
 
@@ -349,7 +349,7 @@ namespace cudaprob3{
         unique_dev_ptr<FLOAT_T> d_energy_list;
         unique_dev_ptr<FLOAT_T> d_cosine_list;
         unique_dev_ptr<FLOAT_T> d_productionHeight_prob_list;
-        unique_dev_ptr<FLOAT_T> d_productionHeightList_paths;
+        unique_dev_ptr<FLOAT_T> d_productionHeightList_hm_hw;
         shared_dev_ptr<FLOAT_T> d_result_list;
 
         cudaStream_t stream;

--- a/cudapropagator.cuh
+++ b/cudapropagator.cuh
@@ -76,7 +76,7 @@ namespace cudaprob3{
             d_energy_list = make_unique_dev<FLOAT_T>(deviceId, n_energies_); CUERR;
             d_cosine_list = make_unique_dev<FLOAT_T>(deviceId, n_cosines_); CUERR;
             d_productionHeight_prob_list = make_unique_dev<FLOAT_T>(deviceId, Constants<FLOAT_T>::MaxProdHeightBins()*2*3*n_energies_*n_cosines_); CUERR;
-            d_productionHeight_bins_list = make_unique_dev<FLOAT_T>(deviceId, Constants<FLOAT_T>::MaxProdHeightBins()+1); CUERR;
+            d_productionHeightList_hm_hw = make_unique_dev<FLOAT_T>(deviceId, Constants<FLOAT_T>::MaxProdHeightBins() * n_cosines_ * 2); CUERR;
             d_result_list = make_shared_dev<FLOAT_T>(deviceId, std::uint64_t(n_cosines_) * std::uint64_t(n_energies_) * std::uint64_t(9)); CUERR;
             d_maxlayers = make_unique_dev<int>(deviceId, this->n_cosines);
         }
@@ -124,7 +124,7 @@ namespace cudaprob3{
             d_energy_list = std::move(other.d_energy_list);
             d_cosine_list = std::move(other.d_cosine_list);
             d_productionHeight_prob_list = std::move(other.d_productionHeight_prob_list);
-            d_productionHeight_bins_list = std::move(other.d_productionHeight_bins_list);
+            d_productionHeightList_hm_hw = std::move(other.d_productionHeightList_hm_hw);
             d_result_list = std::move(other.d_result_list);
 
             deviceId = other.deviceId;

--- a/math.hpp
+++ b/math.hpp
@@ -56,7 +56,7 @@ namespace cudaprob3{
       
         template<typename FLOAT_T>
 	HOSTDEVICEQUALIFIER
-	void multiply_phase_matrix(FLOAT_T Phase, ComplexNumber<FLOAT_T> A[][3], ComplexNumber<FLOAT_T> B[][3]) {
+	void multiply_phase_matrix(FLOAT_T Phase, ComplexNumber<FLOAT_T> A[3][3], ComplexNumber<FLOAT_T> B[3][3]) {
 	  
 #ifdef __CUDACC__
 	  FLOAT_T c,s;
@@ -65,7 +65,7 @@ namespace cudaprob3{
 	  const FLOAT_T s = sin(Phase);
 	  const FLOAT_T c = cos(Phase);
 #endif
-	  
+
 	  for (int i=0; i<3; i++) {
 	    for (int j=0; j<3; j++) {
 	      B[i][j].re += c * A[i][j].re - s * A[i][j].im;
@@ -81,7 +81,7 @@ namespace cudaprob3{
         */
         template<typename FLOAT_T>
         HOSTDEVICEQUALIFIER
-        void multiply_complex_matrix(ComplexNumber<FLOAT_T> A[][3], ComplexNumber<FLOAT_T> B[][3], ComplexNumber<FLOAT_T> C[][3]){
+        void multiply_complex_matrix(ComplexNumber<FLOAT_T> A[3][3], ComplexNumber<FLOAT_T> B[3][3], ComplexNumber<FLOAT_T> C[3][3]){
 
             for (int i=0; i<3; i++) {
 

--- a/physics.hpp
+++ b/physics.hpp
@@ -1002,11 +1002,11 @@ namespace cudaprob3{
                   UNROLLQUALIFIER
                     for (int iPathLength=0;iPathLength<nProductionHeightBins;iPathLength++) {
                       //PathLengthShifts is of size equal to the number of Production Height bin edges
+
                       const FLOAT_T h0 = PathLengthShifts[PathLengthIndex + iPathLength];
                       const FLOAT_T h1 = PathLengthShifts[PathLengthIndex + iPathLength+1];
                       const FLOAT_T hm = (h1+h0)/2.;
                       const FLOAT_T hw = (h1-h0);
-
 
                       UNROLLQUALIFIER
                         for (int iEig0=0;iEig0<nEig;iEig0++) { 
@@ -1024,7 +1024,7 @@ namespace cudaprob3{
                               //sinc(0.5 * darg_distance * hw) * exp(factor).re = sinc(0.5 * darg_distance * hw) * sin(darg_distance * hm)
 
                               math::ComplexNumber<FLOAT_T> sinc_exp_factor; 
-                              FLOAT_T Sinc_Arg = 0.5 * darg_hm;
+                              FLOAT_T Sinc_Arg = 0.5 * darg_distance * hw;
 
                               sinc_exp_factor.re = cudaprob3::math::defined_sinc(Sinc_Arg) * cos(darg_hm);
                               sinc_exp_factor.im = cudaprob3::math::defined_sinc(Sinc_Arg) * sin(darg_hm);

--- a/physics.hpp
+++ b/physics.hpp
@@ -197,30 +197,29 @@ namespace cudaprob3{
     //
     template<typename FLOAT_T>
       void prepare_getMfast(NeutrinoType type) {
-        FLOAT_T alphaV, betaV, gammaV, argV, tmpV;
-        FLOAT_T theta0V, theta1V, theta2V;
         FLOAT_T mMatV[3];
 
         /* The strategy to sort out the three roots is to compute the vacuum
          * mass the same way as the "matter" masses are computed then to sort
          * the results according to the input vacuum masses
          */
-        alphaV = DM(0,1) + DM(0,2);
-        betaV = DM(0,1) * DM(0,2);
-        gammaV = 0.0;
+        FLOAT_T alphaV = DM(0,1) + DM(0,2);
+        FLOAT_T alphaV2 = alphaV*alphaV;
+        FLOAT_T betaV = DM(0,1) * DM(0,2);
+        FLOAT_T gammaV = 0.0;
 
         /* Compute the argument of the arc-cosine */
-        tmpV = alphaV*alphaV-3.0*betaV;
+        FLOAT_T tmpV = alphaV2-3.0*betaV;
 
         /* Equation (21) */
-        argV = (2.0*alphaV*alphaV*alphaV-9.0*alphaV*betaV+27.0*gammaV)/
+        FLOAT_T argV = (2.0*alphaV2*alphaV-9.0*alphaV*betaV+27.0*gammaV)/
           (2.0*sqrt(tmpV*tmpV*tmpV));
         if (fabs(argV)>1.0) argV = argV/fabs(argV);
 
         /* These are the three roots the paper refers to */
-        theta0V = acos(argV)/3.0;
-        theta1V = theta0V-(2.0*M_PI/3.0);
-        theta2V = theta0V+(2.0*M_PI/3.0);
+        FLOAT_T theta0V = acos(argV)/3.0;
+        FLOAT_T theta1V = theta0V - Constants<FLOAT_T>::TwoPiOverThree();
+        FLOAT_T theta2V = theta0V + Constants<FLOAT_T>::TwoPiOverThree();
 
         mMatV[0] = mMatV[1] = mMatV[2] = -(2.0/3.0)*sqrt(tmpV);
         mMatV[0] *= cos(theta0V); mMatV[1] *= cos(theta1V); mMatV[2] *= cos(theta2V);
@@ -267,7 +266,7 @@ namespace cudaprob3{
       HOSTDEVICEQUALIFIER
       void getMfast(const FLOAT_T Enu, const FLOAT_T rho,
           const NeutrinoType type,
-          FLOAT_T d_dmMatMat[][3], FLOAT_T d_dmMatVac[][3]) {
+          FLOAT_T d_dmMatMat[3][3], FLOAT_T d_dmMatVac[3][3]) {
 
         FLOAT_T mMatU[3], mMat[3];
 
@@ -280,6 +279,7 @@ namespace cudaprob3{
         }();
 
         const FLOAT_T alpha  = fac + DM(0,1) + DM(0,2);
+        const FLOAT_T alpha2  = alpha * alpha;
 
         const FLOAT_T beta = DM(0,1)*DM(0,2) +
           fac*(DM(0,1)*(1.0 -
@@ -293,10 +293,10 @@ namespace cudaprob3{
         const FLOAT_T gamma = fac*DM(0,1)*DM(0,2)*(U(0,0).re * U(0,0).re + U(0,0).im * U(0,0).im);
 
         /* Compute the argument of the arc-cosine */
-        const FLOAT_T tmp = alpha*alpha-3.0*beta < 0 ? 0 : alpha*alpha-3.0*beta;
+        const FLOAT_T tmp = alpha2-3.0*beta < 0 ? 0 : alpha2-3.0*beta;
 
         /* Equation (21) */
-        const FLOAT_T argtmp = (2.0*alpha*alpha*alpha-9.0*alpha*beta+27.0*gamma)/
+        const FLOAT_T argtmp = (2.0*alpha2*alpha-9.0*alpha*beta+27.0*gamma)/
           (2.0*sqrt(tmp*tmp*tmp));
         const FLOAT_T arg = [&]() -> FLOAT_T {
           if (fabs(argtmp)>1.0)
@@ -307,12 +307,13 @@ namespace cudaprob3{
 
         /* These are the three roots the paper refers to */
         const FLOAT_T theta0 = acos(arg)/3.0;
-        const FLOAT_T theta1 = theta0-(2.0*M_PI/3.0);
-        const FLOAT_T theta2 = theta0+(2.0*M_PI/3.0);
+        const FLOAT_T theta1 = theta0 - Constants<FLOAT_T>::TwoPiOverThree();
+        const FLOAT_T theta2 = theta0 + Constants<FLOAT_T>::TwoPiOverThree();
 
-        mMatU[0] = -(2.0/3.0)*sqrt(tmp);
-        mMatU[1] = -(2.0/3.0)*sqrt(tmp);
-        mMatU[2] = -(2.0/3.0)*sqrt(tmp);
+        const FLOAT_T baseVal = -(2.0 / 3.0) * sqrt(tmp);
+        mMatU[0] = baseVal;
+        mMatU[1] = baseVal;
+        mMatU[2] = baseVal;
         mMatU[0] *= cos(theta0);
         mMatU[1] *= cos(theta1);
         mMatU[2] *= cos(theta2);
@@ -481,10 +482,11 @@ namespace cudaprob3{
 
             for (int i=0; i<nNuFlav; i++) {
               for (int j=0; j<nNuFlav; j++) {
-                RR_nk[j] += U(iNuFlav,i).re * product[i][j][iExp].re;
-                RI_nk[j] += U(iNuFlav,i).re * product[i][j][iExp].im;
-                IR_nk[j] += U(iNuFlav,i).im * product[i][j][iExp].re;
-                II_nk[j] += U(iNuFlav,i).im * product[i][j][iExp].im;
+                const math::ComplexNumber<FLOAT_T>& p = product[i][j][iExp];
+                RR_nk[j] += U(iNuFlav,i).re * p.re;
+                RI_nk[j] += U(iNuFlav,i).re * p.im;
+                IR_nk[j] += U(iNuFlav,i).im * p.re;
+                II_nk[j] += U(iNuFlav,i).im * p.im;
               }
             }
 
@@ -492,24 +494,18 @@ namespace cudaprob3{
               FLOAT_T ReSum=0., ImSum=0.;
 
               for (int j=0; j<nNuFlav; j++) {
-                ReSum += RR_nk[j] * U(jNuFlav,j).re;
-                ReSum += RI_nk[j] * U(jNuFlav,j).im;
-                ReSum += IR_nk[j] * U(jNuFlav,j).im;
-                ReSum -= II_nk[j] * U(jNuFlav,j).re;
-
-                ImSum += II_nk[j] * U(jNuFlav,j).im;
-                ImSum += IR_nk[j] * U(jNuFlav,j).re;
-                ImSum += RI_nk[j] * U(jNuFlav,j).re;
-                ImSum -= RR_nk[j] * U(jNuFlav,j).im;
+                const FLOAT_T u_re = U(jNuFlav, j).re;
+                const FLOAT_T u_im = U(jNuFlav, j).im;
+                // Combine real and imaginary sums using cached U parts
+                ReSum += (RR_nk[j] - II_nk[j]) * u_re + (RI_nk[j] + IR_nk[j]) * u_im;
+                ImSum += (IR_nk[j] + RI_nk[j]) * u_re + (II_nk[j] - RR_nk[j]) * u_im;
               }
 
               C[iExp][iNuFlav][jNuFlav].re = ReSum;
               C[iExp][iNuFlav][jNuFlav].im = ImSum;
-
             }
           }
         }
-
       }
 
     template<typename FLOAT_T>
@@ -574,7 +570,7 @@ namespace cudaprob3{
                 A[n][m].re = 0;
                 A[n][m].im = 0;
               }
-          }	      
+          }
         UNROLLQUALIFIER
           for (int n=0; n<3; n++) {
             UNROLLQUALIFIER
@@ -800,10 +796,10 @@ namespace cudaprob3{
           const FLOAT_T* const yps,
           const int* const maxlayers,
           FLOAT_T ProductionHeightinCentimeter,
-          bool useProductionHeightAveraging,
-          int nProductionHeightBins,
+          const bool useProductionHeightAveraging,
+          const int nProductionHeightBins,
           const FLOAT_T* const productionHeight_prob_list, // 20 (nBins) * 2 (nu,nubar) * 3 (e,mu,tau) * n_energies * n_cosines
-          const FLOAT_T* const productionHeight_binedges_list, // 21 (BinEdges) in cm
+          const FLOAT_T* const PathLengthShifts, // 21 (BinEdges) in cm
           bool UsePolyDensity, // Use polynomial density?
           FLOAT_T* const result){
 
@@ -889,7 +885,7 @@ namespace cudaprob3{
                 // DB PathLength is used to calculate the distance traversed
                 // in cm
                 const FLOAT_T PathLength = sqrt((Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter )*(Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter)
-                    - (Constants<FLOAT_T>::REarthcm()*Constants<FLOAT_T>::REarthcm())*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith;
+                    - Constants<FLOAT_T>::REarthcm2()*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith;
 
                 //============================================================================================================
                 //DB Loop over layers		    
@@ -974,7 +970,6 @@ namespace cudaprob3{
                     multiply_complex_matrix( TransitionMatrix, finalTransitionMatrix, TransitionTemp );
                     copy_complex_matrix( TransitionTemp, finalTransitionMatrix );
                   }
-
                 }
 
                 // calculate final transition matrix
@@ -999,33 +994,26 @@ namespace cudaprob3{
                             }
                         }
                     }
-
-                  const int nMaxProductionHeightBins = Constants<FLOAT_T>::MaxProdHeightBins();
-                  FLOAT_T PathLengthShifts[nMaxProductionHeightBins+1];
-
-                  UNROLLQUALIFIER
-                    for (int iProductionHeight=0;iProductionHeight<(nProductionHeightBins+1);iProductionHeight++) {
-                      FLOAT_T iVal_ProdHeightInCentimeter = Constants<FLOAT_T>::km2cm() * productionHeight_binedges_list[iProductionHeight];
-                      FLOAT_T iVal_PathLength = (sqrt((Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter )*(Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter)
-                            - (Constants<FLOAT_T>::REarthcm()*Constants<FLOAT_T>::REarthcm())*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith);
-
-                      PathLengthShifts[iProductionHeight] = iVal_PathLength - PathLength;
-                    }
-
+                  const int cosineStride = n_cosines * nProductionHeightBins;
+                  const int energyStride = n_energies * cosineStride;
+                  const int constProb_Index = index_energy * cosineStride + index_cosine*nProductionHeightBins;
+                  const int typeStride = type * nNuFlav * energyStride;
+                  const int PathLengthIndex = index_cosine*(nProductionHeightBins+1);
                   UNROLLQUALIFIER
                     for (int iPathLength=0;iPathLength<nProductionHeightBins;iPathLength++) {
                       //PathLengthShifts is of size equal to the number of Production Height bin edges
-                      const FLOAT_T h0 = PathLengthShifts[iPathLength];
-                      const FLOAT_T h1 = PathLengthShifts[iPathLength+1];
+                      const FLOAT_T h0 = PathLengthShifts[PathLengthIndex + iPathLength];
+                      const FLOAT_T h1 = PathLengthShifts[PathLengthIndex + iPathLength+1];
                       const FLOAT_T hm = (h1+h0)/2.;
                       const FLOAT_T hw = (h1-h0);
+
 
                       UNROLLQUALIFIER
                         for (int iEig0=0;iEig0<nEig;iEig0++) { 
                           UNROLLQUALIFIER
                             for (int jEig0=0;jEig0<iEig0;jEig0++) { 
-                              FLOAT_T darg_distance = darg0_ddistance[iEig0]-darg0_ddistance[jEig0];
-
+                              const FLOAT_T darg_distance = darg0_ddistance[iEig0]-darg0_ddistance[jEig0];
+                              const FLOAT_T darg_hm = darg_distance * hm;
                               //factor.re = 0
                               //factor.im = darg_distance*hm
                               //
@@ -1036,24 +1024,28 @@ namespace cudaprob3{
                               //sinc(0.5 * darg_distance * hw) * exp(factor).re = sinc(0.5 * darg_distance * hw) * sin(darg_distance * hm)
 
                               math::ComplexNumber<FLOAT_T> sinc_exp_factor; 
-                              FLOAT_T Sinc_Arg = 0.5 * darg_distance * hw;
+                              FLOAT_T Sinc_Arg = 0.5 * darg_hm;
 
-                              sinc_exp_factor.re = cudaprob3::math::defined_sinc(Sinc_Arg) * cos(darg_distance * hm);
-                              sinc_exp_factor.im = cudaprob3::math::defined_sinc(Sinc_Arg) * sin(darg_distance * hm);
+                              sinc_exp_factor.re = cudaprob3::math::defined_sinc(Sinc_Arg) * cos(darg_hm);
+                              sinc_exp_factor.im = cudaprob3::math::defined_sinc(Sinc_Arg) * sin(darg_hm);
 
                               UNROLLQUALIFIER
                                 for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //In flav
 
-                                  const int ProbIndex = type*nNuFlav*n_energies*n_cosines*nProductionHeightBins + iNuFlav*n_energies*n_cosines*nProductionHeightBins
-                                    + index_energy*n_cosines*nProductionHeightBins + index_cosine*nProductionHeightBins + iPathLength;
+                                  const int ProbIndex = typeStride + iNuFlav * energyStride + constProb_Index  + iPathLength;
+                                  // If you prefer less compact path
+                                  //const int ProbIndex = type*nNuFlav*n_energies*n_cosines*nProductionHeightBins + iNuFlav*n_energies*n_cosines*nProductionHeightBins
+                                  //+ index_energy*n_cosines*nProductionHeightBins + index_cosine*nProductionHeightBins + iPathLength;
                                   //productionHeight_prob_list is of size equal to the number of production height bins * nNuTypes * nNuFlavouts * n_energies * n_cosines
                                   FLOAT_T ProdHeightProb = productionHeight_prob_list[ProbIndex];
+                                  FLOAT_T deltaRe = ProdHeightProb * sinc_exp_factor.re;
+                                  FLOAT_T deltaIm = ProdHeightProb * sinc_exp_factor.im;
 
-                                  totalLenShiftFactor[iEig0][jEig0][iNuFlav].re += ProdHeightProb * sinc_exp_factor.re;
-                                  totalLenShiftFactor[iEig0][jEig0][iNuFlav].im += ProdHeightProb * sinc_exp_factor.im;
+                                  totalLenShiftFactor[iEig0][jEig0][iNuFlav].re += deltaRe;
+                                  totalLenShiftFactor[iEig0][jEig0][iNuFlav].im += deltaIm;
 
-                                  totalLenShiftFactor[jEig0][iEig0][iNuFlav].re += ProdHeightProb * sinc_exp_factor.re;
-                                  totalLenShiftFactor[jEig0][iEig0][iNuFlav].im -= ProdHeightProb * sinc_exp_factor.im;
+                                  totalLenShiftFactor[jEig0][iEig0][iNuFlav].re += deltaRe;
+                                  totalLenShiftFactor[jEig0][iEig0][iNuFlav].im -= deltaIm;
                                 }
                             }
                         }
@@ -1163,7 +1155,7 @@ namespace cudaprob3{
                 bool useProductionHeightAveraging,
                 int nProductionHeightBins,
                 const FLOAT_T* const productionHeight_prob_list,
-                const FLOAT_T* const productionHeight_binedges_list,
+                const FLOAT_T* const PathLengthShifts,
                 bool UsePolyDensity,
                 FLOAT_T* const result){
 
@@ -1183,7 +1175,7 @@ namespace cudaprob3{
                   useProductionHeightAveraging, 
                   nProductionHeightBins, 
                   productionHeight_prob_list, 
-                  productionHeight_binedges_list, 
+                  PathLengthShifts,
                   UsePolyDensity,
                   result);
             }
@@ -1208,7 +1200,7 @@ namespace cudaprob3{
                 bool useProductionHeightAveraging,
                 int nProductionHeightBins,
                 const FLOAT_T* const productionHeight_prob_list,
-                const FLOAT_T* const productionHeight_binedges_list,
+                const FLOAT_T* const PathLengthShifts,
                 bool UsePolyDensity,
                 FLOAT_T* const result){
 
@@ -1229,19 +1221,12 @@ namespace cudaprob3{
                   useProductionHeightAveraging, 
                   nProductionHeightBins, 
                   productionHeight_prob_list, 
-                  productionHeight_binedges_list,  
+                  PathLengthShifts,
                   UsePolyDensity,
                   result);
               CUERR;
             }
 #endif
-
         }// namespace physics
-
       } // namespace cudaprob3
-
-
-
-
-
 #endif

--- a/physics.hpp
+++ b/physics.hpp
@@ -764,13 +764,13 @@ namespace cudaprob3{
         // Impact parameter for this cos zenith (nearest distance from center)
         // in km this time
         const FLOAT_T R2min = Constants<FLOAT_T>::REarth()*Constants<FLOAT_T>::REarth()*(1-cosine_zenith*cosine_zenith);
-
+        const FLOAT_T sqrt_R2min = sqrt(R2min);
         // in km
         FLOAT_T CrossThis = 2.0*sqrt(radii[i]*radii[i] - R2min);
-        if (sqrt(R2min) > radii[i]) CrossThis = 0;
+        if (sqrt_R2min > radii[i]) CrossThis = 0;
         // in km
         FLOAT_T CrossNext = 2.0*sqrt(radii[i+1]*radii[i+1] - R2min);
-        if (sqrt(R2min) > radii[i+1]) CrossNext = 0;
+        if (sqrt_R2min > radii[i+1]) CrossNext = 0;
 
         if (i < max_layer - 1) {
           // Convert to cm
@@ -783,25 +783,25 @@ namespace cudaprob3{
 
     template<typename FLOAT_T>
       HOSTDEVICEQUALIFIER
-      void calculate(NeutrinoType type,
-          const FLOAT_T* const cosinelist,
-          int n_cosines,
-          const FLOAT_T* const energylist,
-          int n_energies,
-          const FLOAT_T* const radii,
-          const FLOAT_T* const as,
-          const FLOAT_T* const bs,
-          const FLOAT_T* const cs,
-          const FLOAT_T* const rhos,
-          const FLOAT_T* const yps,
-          const int* const maxlayers,
-          FLOAT_T ProductionHeightinCentimeter,
+      void calculate(const NeutrinoType type,
+          const FLOAT_T* __restrict__ cosinelist,
+          const int n_cosines,
+          const FLOAT_T* __restrict__ energylist,
+          const int n_energies,
+          const FLOAT_T* __restrict__ radii,
+          const FLOAT_T* __restrict__ as,
+          const FLOAT_T* __restrict__ bs,
+          const FLOAT_T* __restrict__ cs,
+          const FLOAT_T* __restrict__ rhos,
+          const FLOAT_T* __restrict__ yps,
+          const int* __restrict__  maxlayers,
+          const FLOAT_T ProductionHeightinCentimeter,
           const bool useProductionHeightAveraging,
           const int nProductionHeightBins,
-          const FLOAT_T* const productionHeight_prob_list, // 20 (nBins) * 2 (nu,nubar) * 3 (e,mu,tau) * n_energies * n_cosines
-          const FLOAT_T* const PathLengthShifts, // 21 (BinEdges) in cm
-          bool UsePolyDensity, // Use polynomial density?
-          FLOAT_T* const result){
+          const FLOAT_T* __restrict__ productionHeight_prob_list, // 20 (nBins) * 2 (nu,nubar) * 3 (e,mu,tau) * n_energies * n_cosines
+          const FLOAT_T* __restrict__ PathLength_hm_hw, // 21 (BinEdges) in cm
+          const bool UsePolyDensity, // Use polynomial density?
+          FLOAT_T* const result) {
 
         //prepare more constant data. For the kernel, this is done by the wrapper function callCalculateKernelAsync
 #ifndef __CUDA_ARCH__
@@ -996,17 +996,14 @@ namespace cudaprob3{
                     }
                   const int cosineStride = n_cosines * nProductionHeightBins;
                   const int energyStride = n_energies * cosineStride;
-                  const int constProb_Index = index_energy * cosineStride + index_cosine*nProductionHeightBins;
+                  const int cosineProdHeightOffset = index_cosine * nProductionHeightBins;
+                  const int constProb_Index = index_energy * cosineStride + cosineProdHeightOffset;
                   const int typeStride = type * nNuFlav * energyStride;
-                  const int PathLengthIndex = index_cosine*(nProductionHeightBins+1);
+                  const int PathLengthIndex = cosineProdHeightOffset * 2;
                   UNROLLQUALIFIER
                     for (int iPathLength=0;iPathLength<nProductionHeightBins;iPathLength++) {
-                      //PathLengthShifts is of size equal to the number of Production Height bin edges
-
-                      const FLOAT_T h0 = PathLengthShifts[PathLengthIndex + iPathLength];
-                      const FLOAT_T h1 = PathLengthShifts[PathLengthIndex + iPathLength+1];
-                      const FLOAT_T hm = (h1+h0)/2.;
-                      const FLOAT_T hw = (h1-h0);
+                      const FLOAT_T hm = PathLength_hm_hw[PathLengthIndex + 2 * iPathLength];
+                      const FLOAT_T hw = PathLength_hm_hw[PathLengthIndex + 2 * iPathLength + 1];
 
                       UNROLLQUALIFIER
                         for (int iEig0=0;iEig0<nEig;iEig0++) { 
@@ -1025,10 +1022,10 @@ namespace cudaprob3{
 
                               math::ComplexNumber<FLOAT_T> sinc_exp_factor; 
                               FLOAT_T Sinc_Arg = 0.5 * darg_distance * hw;
+                              FLOAT_T SincVal  = cudaprob3::math::defined_sinc(Sinc_Arg);
 
-                              sinc_exp_factor.re = cudaprob3::math::defined_sinc(Sinc_Arg) * cos(darg_hm);
-                              sinc_exp_factor.im = cudaprob3::math::defined_sinc(Sinc_Arg) * sin(darg_hm);
-
+                              sinc_exp_factor.re = SincVal * cos(darg_hm);
+                              sinc_exp_factor.im = SincVal * sin(darg_hm);
                               UNROLLQUALIFIER
                                 for (int iNuFlav=0;iNuFlav<nNuFlav;iNuFlav++) { //In flav
 
@@ -1037,9 +1034,9 @@ namespace cudaprob3{
                                   //const int ProbIndex = type*nNuFlav*n_energies*n_cosines*nProductionHeightBins + iNuFlav*n_energies*n_cosines*nProductionHeightBins
                                   //+ index_energy*n_cosines*nProductionHeightBins + index_cosine*nProductionHeightBins + iPathLength;
                                   //productionHeight_prob_list is of size equal to the number of production height bins * nNuTypes * nNuFlavouts * n_energies * n_cosines
-                                  FLOAT_T ProdHeightProb = productionHeight_prob_list[ProbIndex];
-                                  FLOAT_T deltaRe = ProdHeightProb * sinc_exp_factor.re;
-                                  FLOAT_T deltaIm = ProdHeightProb * sinc_exp_factor.im;
+                                  const FLOAT_T ProdHeightProb = productionHeight_prob_list[ProbIndex];
+                                  const FLOAT_T deltaRe = ProdHeightProb * sinc_exp_factor.re;
+                                  const FLOAT_T deltaIm = ProdHeightProb * sinc_exp_factor.im;
 
                                   totalLenShiftFactor[iEig0][jEig0][iNuFlav].re += deltaRe;
                                   totalLenShiftFactor[iEig0][jEig0][iNuFlav].im += deltaIm;
@@ -1139,23 +1136,23 @@ namespace cudaprob3{
           template<typename FLOAT_T>
             KERNEL
             __launch_bounds__( 64, 8 )
-            void calculateKernel(NeutrinoType type,
-                const FLOAT_T* const cosinelist,
-                int n_cosines,
-                const FLOAT_T* const energylist,
-                int n_energies,
-                const FLOAT_T* const radii,
-                const FLOAT_T* const as,
-                const FLOAT_T* const bs,
-                const FLOAT_T* const cs,
-                const FLOAT_T* const rhos,
-                const FLOAT_T* const yps,
-                const int* const maxlayers,
-                FLOAT_T ProductionHeightinCentimeter,
-                bool useProductionHeightAveraging,
-                int nProductionHeightBins,
-                const FLOAT_T* const productionHeight_prob_list,
-                const FLOAT_T* const PathLengthShifts,
+            void calculateKernel(const NeutrinoType type,
+                const FLOAT_T* __restrict__ cosinelist,
+                const int n_cosines,
+                const FLOAT_T* __restrict__ energylist,
+                const int n_energies,
+                const FLOAT_T* __restrict__ radii,
+                const FLOAT_T* __restrict__ as,
+                const FLOAT_T* __restrict__ bs,
+                const FLOAT_T* __restrict__ cs,
+                const FLOAT_T* __restrict__ rhos,
+                const FLOAT_T* __restrict__ yps,
+                const int* __restrict__ maxlayers,
+                const FLOAT_T ProductionHeightinCentimeter,
+                const bool useProductionHeightAveraging,
+                const int nProductionHeightBins,
+                const FLOAT_T* __restrict__ productionHeight_prob_list,
+                const FLOAT_T* __restrict__ PathLength_hm_hw,
                 bool UsePolyDensity,
                 FLOAT_T* const result){
 
@@ -1175,7 +1172,7 @@ namespace cudaprob3{
                   useProductionHeightAveraging, 
                   nProductionHeightBins, 
                   productionHeight_prob_list, 
-                  PathLengthShifts,
+                  PathLength_hm_hw,
                   UsePolyDensity,
                   result);
             }
@@ -1184,24 +1181,24 @@ namespace cudaprob3{
             void callCalculateKernelAsync(dim3 grid,
                 dim3 block,
                 cudaStream_t stream,
-                NeutrinoType type,
-                const FLOAT_T* const cosinelist,
-                int n_cosines,
-                const FLOAT_T* const energylist,
-                int n_energies,
-                const FLOAT_T* const radii,
-                const FLOAT_T* const as,
-                const FLOAT_T* const bs,
-                const FLOAT_T* const cs,
-                const FLOAT_T* const rhos,
-                const FLOAT_T* const yps,
-                const int* const maxlayers,
-                FLOAT_T ProductionHeightinCentimeter,
-                bool useProductionHeightAveraging,
-                int nProductionHeightBins,
-                const FLOAT_T* const productionHeight_prob_list,
-                const FLOAT_T* const PathLengthShifts,
-                bool UsePolyDensity,
+                const NeutrinoType type,
+                const FLOAT_T* __restrict__ cosinelist,
+                const int n_cosines,
+                const FLOAT_T* __restrict__ energylist,
+                const int n_energies,
+                const FLOAT_T* __restrict__ radii,
+                const FLOAT_T* __restrict__ as,
+                const FLOAT_T* __restrict__ bs,
+                const FLOAT_T* __restrict__ cs,
+                const FLOAT_T* __restrict__ rhos,
+                const FLOAT_T* __restrict__ yps,
+                const int* __restrict__ maxlayers,
+                const FLOAT_T ProductionHeightinCentimeter,
+                const bool useProductionHeightAveraging,
+                const int nProductionHeightBins,
+                const FLOAT_T* __restrict__ productionHeight_prob_list,
+                const FLOAT_T* __restrict__ PathLength_hm_hw,
+                const bool UsePolyDensity,
                 FLOAT_T* const result){
 
               prepare_getMfast<FLOAT_T>(type);
@@ -1221,7 +1218,7 @@ namespace cudaprob3{
                   useProductionHeightAveraging, 
                   nProductionHeightBins, 
                   productionHeight_prob_list, 
-                  PathLengthShifts,
+                  PathLength_hm_hw,
                   UsePolyDensity,
                   result);
               CUERR;

--- a/propagator.hpp
+++ b/propagator.hpp
@@ -614,18 +614,29 @@ namespace cudaprob3{
 
 
         const int nMaxProductionHeightBins = Constants<FLOAT_T>::MaxProdHeightBins();
-        productionHeightList_paths.resize((nMaxProductionHeightBins+1)*n_cosines);
+        productionHeightList_hm_hw.resize(n_cosines * nProductionHeightBins * 2);
 
         for(int index_cosine = 0; index_cosine < n_cosines; index_cosine += 1) {
           const FLOAT_T cosine_zenith = cosineList[index_cosine];
           const FLOAT_T PathLength = sqrt((Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter )*(Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter)
           - (Constants<FLOAT_T>::REarthcm()*Constants<FLOAT_T>::REarthcm())*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith;
+
+          std::vector<FLOAT_T> rawPathLengths(nProductionHeightBins + 1);
           for (int iProductionHeight=0;iProductionHeight<(nProductionHeightBins+1);iProductionHeight++) {
             FLOAT_T iVal_ProdHeightInCentimeter = Constants<FLOAT_T>::km2cm() * productionHeightList_bins[iProductionHeight];
             FLOAT_T iVal_PathLength = (sqrt((Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter )*(Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter)
             - Constants<FLOAT_T>::REarthcm2()*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith);
 
-            productionHeightList_paths.at(index_cosine * (nProductionHeightBins + 1) + iProductionHeight) = iVal_PathLength - PathLength;
+            rawPathLengths[iProductionHeight] = iVal_PathLength - PathLength;
+          }
+
+          // Compute hm and hw, store interleaved in productionHeightList_hm_hw
+          for (int iProductionHeight = 0; iProductionHeight < nProductionHeightBins; iProductionHeight++) {
+            const FLOAT_T h0 = rawPathLengths[iProductionHeight];
+            const FLOAT_T h1 = rawPathLengths[iProductionHeight + 1];
+
+            productionHeightList_hm_hw[(index_cosine * nProductionHeightBins + iProductionHeight) * 2 + 0] = (h0 + h1) * 0.5;  // hm
+            productionHeightList_hm_hw[(index_cosine * nProductionHeightBins + iProductionHeight) * 2 + 1] = (h1 - h0);        // hw
           }
         }
         isSetProductionHeightArray = true;
@@ -685,7 +696,9 @@ namespace cudaprob3{
       std::vector<FLOAT_T> productionHeightList_prob;
       std::vector<FLOAT_T> productionHeightList_bins;
 
-      std::vector<FLOAT_T> productionHeightList_paths;
+      /// @brief Midpoint (hm) and half-width (hw) of each production height bin for each cosine.
+      /// Stored as a flattened array: [cosine][bin0_hm, bin0_hw, bin1_hm, bin1_hw, ...]
+      std::vector<FLOAT_T> productionHeightList_hm_hw;
 
       std::vector<FLOAT_T> radii;
       std::vector<FLOAT_T> rhos;

--- a/propagator.hpp
+++ b/propagator.hpp
@@ -612,6 +612,22 @@ namespace cudaprob3{
           productionHeightList_bins[i] = list_bins[i];
         }
 
+
+        const int nMaxProductionHeightBins = Constants<FLOAT_T>::MaxProdHeightBins();
+        productionHeightList_paths.resize((nMaxProductionHeightBins+1)*n_cosines);
+
+        for(int index_cosine = 0; index_cosine < n_cosines; index_cosine += 1) {
+          const FLOAT_T cosine_zenith = cosineList[index_cosine];
+          const FLOAT_T PathLength = sqrt((Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter )*(Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter)
+          - (Constants<FLOAT_T>::REarthcm()*Constants<FLOAT_T>::REarthcm())*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith;
+          for (int iProductionHeight=0;iProductionHeight<(nProductionHeightBins+1);iProductionHeight++) {
+            FLOAT_T iVal_ProdHeightInCentimeter = Constants<FLOAT_T>::km2cm() * productionHeightList_bins[iProductionHeight];
+            FLOAT_T iVal_PathLength = (sqrt((Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter )*(Constants<FLOAT_T>::REarthcm() + iVal_ProdHeightInCentimeter)
+            - Constants<FLOAT_T>::REarthcm2()*( 1 - cosine_zenith*cosine_zenith)) - Constants<FLOAT_T>::REarthcm()*cosine_zenith);
+
+            productionHeightList_paths.at(index_cosine * (nProductionHeightBins + 1) + iProductionHeight) = iVal_PathLength - PathLength;
+          }
+        }
         isSetProductionHeightArray = true;
       }
 
@@ -668,6 +684,8 @@ namespace cudaprob3{
 
       std::vector<FLOAT_T> productionHeightList_prob;
       std::vector<FLOAT_T> productionHeightList_bins;
+
+      std::vector<FLOAT_T> productionHeightList_paths;
 
       std::vector<FLOAT_T> radii;
       std::vector<FLOAT_T> rhos;

--- a/propagator.hpp
+++ b/propagator.hpp
@@ -613,9 +613,7 @@ namespace cudaprob3{
         }
 
 
-        const int nMaxProductionHeightBins = Constants<FLOAT_T>::MaxProdHeightBins();
         productionHeightList_hm_hw.resize(n_cosines * nProductionHeightBins * 2);
-
         for(int index_cosine = 0; index_cosine < n_cosines; index_cosine += 1) {
           const FLOAT_T cosine_zenith = cosineList[index_cosine];
           const FLOAT_T PathLength = sqrt((Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter )*(Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter)


### PR DESCRIPTION
# description
Several speed up ideas:
- Now we cache hw and hm isntead of claucaitng it every iteration
- Plenty of speed related to reducing simple calcuations
- Use of restrict
- Pre calcaute stuff like two over pi or earth radius squared

# Plots
Both CPU and GPU see nice speedup
![image](https://github.com/user-attachments/assets/087e2570-9cbe-4cc3-a53b-b83e96225a42)

# Validations
Before
[Before.txt](https://github.com/user-attachments/files/20901404/Before.txt)
After
[After.txt](https://github.com/user-attachments/files/20901406/After.txt)
After with GPU
[AfterGPU.txt](https://github.com/user-attachments/files/20901407/AfterGPU.txt)
