### PR TITLE
Multiplication result converted to larger type

### DIFF
--- a/cpupropagator.hpp
+++ b/cpupropagator.hpp
@@ -138,9 +138,11 @@ namespace cudaprob3{
         void getProbabilityArr(FLOAT_T* probArr, ProbType t) override{
 
           std::uint64_t iter = 0;
-          for (std::uint64_t index_energy=0;index_energy<this->n_energies;index_energy++) {
-            for (std::uint64_t index_cosine=0;index_cosine<this->n_cosines;index_cosine++) {
-              std::uint64_t index = std::uint64_t(index_cosine) * std::uint64_t(this->n_energies) * std::uint64_t(9) + std::uint64_t(index_energy) * std::uint64_t(9);
+          const std::uint64_t stride = std::uint64_t(this->n_energies) * std::uint64_t(9);
+          for (std::uint64_t index_energy=0;index_energy<this->n_energies;++index_energy) {
+            const std::uint64_t base_energy_offset = std::uint64_t(index_energy) * std::uint64_t(9);
+            for (std::uint64_t index_cosine=0;index_cosine<this->n_cosines;++index_cosine) {
+              std::uint64_t index = std::uint64_t(index_cosine) * stride + base_energy_offset;
               probArr[iter] = resultList[index + int(t)];
               iter += 1;
             }

--- a/physics.hpp
+++ b/physics.hpp
@@ -458,8 +458,13 @@ namespace cudaprob3{
      ***********************************************************************/
     template<typename FLOAT_T>
       HOSTDEVICEQUALIFIER
-      void getC(FLOAT_T E, FLOAT_T rho, FLOAT_T dmMatVac[][3], FLOAT_T dmMatMat[][3],
-          cudaprob3::NeutrinoType type, FLOAT_T phase_offset, math::ComplexNumber<FLOAT_T> C[3][3][3]) {
+      void getC(const FLOAT_T E,
+                const FLOAT_T rho,
+                const FLOAT_T dmMatVac[3][3],
+                const FLOAT_T dmMatMat[3][3],
+                const cudaprob3::NeutrinoType type,
+                const FLOAT_T phase_offset,
+                math::ComplexNumber<FLOAT_T> C[3][3][3]) {
 
         const int nExp = 3;
         const int nNuFlav = 3;

--- a/propagator.hpp
+++ b/propagator.hpp
@@ -613,7 +613,7 @@ namespace cudaprob3{
         }
 
 
-        productionHeightList_hm_hw.resize(n_cosines * nProductionHeightBins * 2);
+        productionHeightList_hm_hw.resize(static_cast<size_t>(n_cosines) * nProductionHeightBins * 2);
         for(int index_cosine = 0; index_cosine < n_cosines; index_cosine += 1) {
           const FLOAT_T cosine_zenith = cosineList[index_cosine];
           const FLOAT_T PathLength = sqrt((Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter )*(Constants<FLOAT_T>::REarthcm() + ProductionHeightinCentimeter)


### PR DESCRIPTION
Fix this issue: https://github.com/mach3-software/MaCh3/security/code-scanning/2139
In addition getC has all arguemtns const for const correctness

In `getProbabilityArr `some values are computed less freqent which should result in very minor performance increase.